### PR TITLE
0.0.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,4 +267,4 @@ print(function()(123, 456))
 #> function.<locals>.SomeClass(a=123, b=456)
 ```
 
-> ⚠️ Automatic mode is currently experimental, so there may be some bugs.
+> ⚠️ Auto mode is currently experimental, so there may be some bugs.

--- a/README.md
+++ b/README.md
@@ -255,16 +255,16 @@ print(SomeClass(123, 456))
 By default, the class name is displayed based on its `__name__` attribute, but you can configure it to use the `__qualname__` attribute instead:
 
 ```python
-# Imagine that this code is in module some.path.to 
+def function():
+    @repred(qualname=True)
+    class SomeClass:
+        def __init__(self, a, b):
+            self.a = a
+            self.b = b
+    return SomeClass
 
-@repred(qualname=True)
-class SomeClass:
-    def __init__(self, a, b):
-        self.a = a
-        self.b = b
-
-print(SomeClass(123, 456))
-#> some.path.to.SomeClass(a=123, b=456)
+print(function()(123, 456))
+#> function.<locals>.SomeClass(a=123, b=456)
 ```
 
 > ⚠️ Automatic mode is currently experimental, so there may be some bugs.

--- a/README.md
+++ b/README.md
@@ -222,4 +222,49 @@ print(Class2(123, 456))
 #> Class2(123, 456)
 ```
 
+If you want to prevent certain `__init__` parameters from being displayed, you can add their names to the ignore list:
+
+```python
+@repred(ignore=['a'])
+class SomeClass:
+    def __init__(self, a, b):
+        self.a = a
+        self.b = b
+
+print(SomeClass(123, 456))
+#> SomeClass(b=456)
+```
+
+You can also add value-based filters for individual arguments by passing a `dict` of filters, similar to how it works in [manual mode](#filtering):
+
+```python
+from printo import not_none
+
+@repred(filters={'a': not_none})
+class SomeClass:
+    def __init__(self, a, b):
+        self.a = a
+        self.b = b
+
+print(SomeClass(None, None))
+#> SomeClass(b=None)
+print(SomeClass(123, 456))
+#> SomeClass(a=123, b=456)
+```
+
+By default, the class name is displayed based on its `__name__` attribute, but you can configure it to use the `__qualname__` attribute instead:
+
+```python
+# Imagine that this code is in module some.path.to 
+
+@repred(qualname=True)
+class SomeClass:
+    def __init__(self, a, b):
+        self.a = a
+        self.b = b
+
+print(SomeClass(123, 456))
+#> some.path.to.SomeClass(a=123, b=456)
+```
+
 > ⚠️ Automatic mode is currently experimental, so there may be some bugs.

--- a/printo/repred.py
+++ b/printo/repred.py
@@ -51,7 +51,7 @@ def repred(cls: Optional[ClassType] = None, prefer_positional: bool = False, qua
     )
 
     if cls is None:
-        return partial(repred, prefer_positional=prefer_positional, qualname=qualname, getters=getters, filters=filters)  # type: ignore[return-value]
+        return partial(repred, prefer_positional=prefer_positional, qualname=qualname, getters=getters, filters=filters, ignore=ignore)  # type: ignore[return-value]
 
     if not isclass(cls):
         raise ValueError('The @repred decorator can only be applied to classes.')
@@ -80,7 +80,7 @@ def repred(cls: Optional[ClassType] = None, prefer_positional: bool = False, qua
     if ignore is not None:
         for parameter_name in ignore:
             if not parameter_name.isidentifier():
-                raise ValueError
+                raise ValueError(f'You have specified the parameter name {parameter_name!r} to ignore, which is not a valid identifier name in Python.')
     else:
         ignore = []
     ignored_parameters = set(ignore)

--- a/printo/repred.py
+++ b/printo/repred.py
@@ -1,7 +1,7 @@
 from ast import Assign, Attribute, Name, parse
 from functools import partial
 from inspect import Parameter, Signature, getattr_static, isclass, signature
-from typing import Any, Callable, Dict, Iterable, Optional, Type, TypeVar, Union, cast
+from typing import Any, Callable, Dict, Iterable, Optional, Type, TypeVar, Union, List, cast
 
 from getsources import getclearsource
 
@@ -21,7 +21,10 @@ def get_mapping(cls: ClassType) -> Dict[str, str]:
     try:
         self_name = tree.body[0].args.posonlyargs[0].arg  # type: ignore[attr-defined]
     except IndexError:
-        self_name = tree.body[0].args.args[0].arg  # type: ignore[attr-defined]
+        try:
+            self_name = tree.body[0].args.args[0].arg  # type: ignore[attr-defined]
+        except IndexError as e:
+            raise ParameterMappingNotFoundError(f'It seems that the "self" argument was not found for the __init__ method of class {cls.__name__}.') from e
 
     results = {}
     for node in tree.body[0].body:  # type: ignore[attr-defined]
@@ -30,7 +33,7 @@ def get_mapping(cls: ClassType) -> Dict[str, str]:
 
     return results
 
-def repred(cls: Optional[ClassType] = None, prefer_positional: bool = False, qualname: bool = False, getters: Optional[Dict[str, Callable[[ClassType], Any]]] = None, filters: Optional[Dict[Union[str, int], Callable[[Any], bool]]] = None) -> Union[ClassType, Callable[[ClassType], ClassType]]:  # noqa: PLR0915
+def repred(cls: Optional[ClassType] = None, prefer_positional: bool = False, qualname: bool = False, getters: Optional[Dict[str, Callable[[ClassType], Any]]] = None, filters: Optional[Dict[Union[str, int], Callable[[Any], bool]]] = None, ignore: Optional[List[str]] = None) -> Union[ClassType, Callable[[ClassType], ClassType]]:  # noqa: PLR0915
     from sigmatch import (  # noqa: PLC0415
         PossibleCallMatcher,
         SignatureMismatchError,
@@ -63,6 +66,14 @@ def repred(cls: Optional[ClassType] = None, prefer_positional: bool = False, qua
     else:
         filters = {}
 
+    if ignore is not None:
+        for parameter_name in ignore:
+            if not parameter_name.isidentifier():
+                raise ValueError()
+    else:
+        ignore = []
+    ignored_parameters = set(ignore)
+
     names_mapping = get_mapping(cls)
 
     positional_getters = {}
@@ -94,25 +105,30 @@ def repred(cls: Optional[ClassType] = None, prefer_positional: bool = False, qua
 
             all_parameter_names.add(parameter_name)
 
-            if parameter_name not in names_mapping and parameter_name not in default_getters and parameter.default == parameter.empty:
+            if parameter_name not in names_mapping and parameter_name not in default_getters and parameter.default == parameter.empty and parameter_name not in ignored_parameters:
                 parameters_not_found.append(parameter_name)
 
-            if parameter.kind == Parameter.POSITIONAL_ONLY:
-                positional_getters[parameter_name] = partial((lambda key, object_of_this_class: getattr(object_of_this_class, names_mapping[key])), parameter_name)
-            elif parameter.kind == Parameter.KEYWORD_ONLY:
-                keyword_getters[parameter_name] = partial((lambda key, object_of_this_class: getattr(object_of_this_class, names_mapping[key])), parameter_name)
-            elif parameter.kind == Parameter.POSITIONAL_OR_KEYWORD:
-                if prefer_positional or one_star_parameter is not None:
+            if parameter_name not in ignored_parameters:
+                if parameter.kind == Parameter.POSITIONAL_ONLY:
                     positional_getters[parameter_name] = partial((lambda key, object_of_this_class: getattr(object_of_this_class, names_mapping[key])), parameter_name)
-                else:
+                elif parameter.kind == Parameter.KEYWORD_ONLY:
                     keyword_getters[parameter_name] = partial((lambda key, object_of_this_class: getattr(object_of_this_class, names_mapping[key])), parameter_name)
+                elif parameter.kind == Parameter.POSITIONAL_OR_KEYWORD:
+                    if prefer_positional or one_star_parameter is not None:
+                        positional_getters[parameter_name] = partial((lambda key, object_of_this_class: getattr(object_of_this_class, names_mapping[key])), parameter_name)
+                    else:
+                        keyword_getters[parameter_name] = partial((lambda key, object_of_this_class: getattr(object_of_this_class, names_mapping[key])), parameter_name)
 
-            if parameter.default != parameter.empty:
-                default_values[parameter_name] = parameter.default
+                if parameter.default != parameter.empty:
+                    default_values[parameter_name] = parameter.default
 
     for parameter_name in default_getters:
         if parameter_name not in all_parameter_names:
             raise NameError(f'Parameter "{parameter_name}" is not used when initializing objects of class {cls.__name__}, but you have defined a getter for it.')
+
+    for parameter_name in ignored_parameters:
+        if parameter_name not in all_parameter_names:
+            raise NameError(f'Parameter "{parameter_name}" is not used when initializing objects of class {cls.__name__}, but you have defined it as an ignored one.')
 
     if parameters_not_found:
         raise ParameterMappingNotFoundError(f'No internal object {"properties" if len(parameters_not_found) > 1 else "property"} or custom {"getters" if len(parameters_not_found) > 1 else "getter"} {"were" if len(parameters_not_found) > 1 else "was"} found for the {"parameters" if len(parameters_not_found) > 1 else "parameter"} {", ".join(parameters_not_found)}.')

--- a/printo/repred.py
+++ b/printo/repred.py
@@ -59,7 +59,7 @@ def repred(cls: Optional[ClassType] = None, prefer_positional: bool = False, qua
             if not isinstance(parameter_name_or_id, (int, str)) or (isinstance(parameter_name_or_id, int) and parameter_name_or_id < 0) or (isinstance(parameter_name_or_id, str) and not parameter_name_or_id.isidentifier()):
                 raise ValueError('Keys for a filtered dictionary can be either integers starting from 0 or strings (parameter names).')
             if not matcher.match(filter_function):
-                raise SignatureMismatchError(f'')
+                raise SignatureMismatchError(f'You have defined a getter for parameter "{parameter_name_or_id}" that cannot be called with a single argument.')
     else:
         filters = {}
 

--- a/printo/repred.py
+++ b/printo/repred.py
@@ -30,20 +30,20 @@ def get_mapping(cls: ClassType) -> Dict[str, str]:
 
     return results
 
-def repred(cls: Optional[ClassType] = None, prefer_positional: bool = False, getters: Optional[Dict[str, Callable[[ClassType], Any]]] = None) -> Union[ClassType, Callable[[ClassType], ClassType]]:  # noqa: PLR0915
+def repred(cls: Optional[ClassType] = None, prefer_positional: bool = False, qualname: bool = False, getters: Optional[Dict[str, Callable[[ClassType], Any]]] = None, filters: Optional[Dict[Union[str, int], Callable[[Any], bool]]] = None) -> Union[ClassType, Callable[[ClassType], ClassType]]:  # noqa: PLR0915
+    from sigmatch import (  # noqa: PLC0415
+        PossibleCallMatcher,
+        SignatureMismatchError,
+    )
+
     if cls is None:
-        return partial(repred, prefer_positional=prefer_positional, getters=getters)  # type: ignore[return-value]
+        return partial(repred, prefer_positional=prefer_positional, qualname=qualname, getters=getters, filters=filters)  # type: ignore[return-value]
 
     if not isclass(cls):
         raise ValueError('The @repred decorator can only be applied to classes.')
     if '__repr__' in cls.__dict__:
         raise RedefinitionError(f'Class {cls.__name__} already has its own __repr__ method defined; you cannot override it.')
     if getters is not None:
-        from sigmatch import (  # noqa: PLC0415
-            PossibleCallMatcher,
-            SignatureMismatchError,
-        )
-
         matcher = PossibleCallMatcher('.')
         for parameter_name, getter in getters.items():
             if not matcher.match(getter):
@@ -52,6 +52,16 @@ def repred(cls: Optional[ClassType] = None, prefer_positional: bool = False, get
         default_getters = getters
     else:
         default_getters = {}
+
+    if filters is not None:
+        matcher = PossibleCallMatcher('.')
+        for parameter_name_or_id, filter_function in filters.items():
+            if not isinstance(parameter_name_or_id, (int, str)) or (isinstance(parameter_name_or_id, int) and parameter_name_or_id < 0) or (isinstance(parameter_name_or_id, str) and not parameter_name_or_id.isidentifier()):
+                raise ValueError('Keys for a filtered dictionary can be either integers starting from 0 or strings (parameter names).')
+            if not matcher.match(filter_function):
+                raise SignatureMismatchError(f'')
+    else:
+        filters = {}
 
     names_mapping = get_mapping(cls)
 
@@ -125,10 +135,14 @@ def repred(cls: Optional[ClassType] = None, prefer_positional: bool = False, get
         if two_stars_parameter is not None:
             keywords.update(two_stars_parameter(self))
 
+        class_name = cls.__qualname__ if qualname else cls.__name__
+
+
         return describe_data_object(
-            cls.__name__,
+            class_name,
             positionals,
             keywords,
+            filters=filters,
         )
 
     cls.__repr__ = __repr__  # type: ignore[assignment]

--- a/printo/repred.py
+++ b/printo/repred.py
@@ -1,7 +1,18 @@
 from ast import Assign, Attribute, Name, parse
 from functools import partial
 from inspect import Parameter, Signature, getattr_static, isclass, signature
-from typing import Any, Callable, Dict, Iterable, Optional, Type, TypeVar, Union, List, cast
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Type,
+    TypeVar,
+    Union,
+    cast,
+)
 
 from getsources import getclearsource
 
@@ -33,7 +44,7 @@ def get_mapping(cls: ClassType) -> Dict[str, str]:
 
     return results
 
-def repred(cls: Optional[ClassType] = None, prefer_positional: bool = False, qualname: bool = False, getters: Optional[Dict[str, Callable[[ClassType], Any]]] = None, filters: Optional[Dict[Union[str, int], Callable[[Any], bool]]] = None, ignore: Optional[List[str]] = None) -> Union[ClassType, Callable[[ClassType], ClassType]]:  # noqa: PLR0915
+def repred(cls: Optional[ClassType] = None, prefer_positional: bool = False, qualname: bool = False, getters: Optional[Dict[str, Callable[[ClassType], Any]]] = None, filters: Optional[Dict[Union[str, int], Callable[[Any], bool]]] = None, ignore: Optional[List[str]] = None) -> Union[ClassType, Callable[[ClassType], ClassType]]:  # noqa: PLR0915, PLR0913
     from sigmatch import (  # noqa: PLC0415
         PossibleCallMatcher,
         SignatureMismatchError,
@@ -69,7 +80,7 @@ def repred(cls: Optional[ClassType] = None, prefer_positional: bool = False, qua
     if ignore is not None:
         for parameter_name in ignore:
             if not parameter_name.isidentifier():
-                raise ValueError()
+                raise ValueError
     else:
         ignore = []
     ignored_parameters = set(ignore)

--- a/printo/repred.py
+++ b/printo/repred.py
@@ -103,8 +103,8 @@ def repred(cls: Optional[ClassType] = None, prefer_positional: bool = False, qua
         parameters = []
 
     for position, parameter in enumerate(parameters):
-        if position:
-            parameter_name = parameter.name
+        parameter_name = parameter.name
+        if position and parameter_name not in ignored_parameters:
             if parameter.kind == Parameter.VAR_POSITIONAL:
                 one_star_parameter = partial((lambda key, object_of_this_class: getattr(object_of_this_class, names_mapping[key])), parameter_name)
             elif parameter.kind == Parameter.VAR_KEYWORD:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = 'setuptools.build_meta'
 
 [project]
 name = 'printo'
-version = '0.0.17'
+version = '0.0.18'
 authors = [
   { name='Evgeniy Blinov', email='zheni-b@yandex.ru' },
 ]

--- a/tests/units/test_repred.py
+++ b/tests/units/test_repred.py
@@ -315,3 +315,23 @@ def test_set_filters():
             self.x = args
 
     assert repr(Class3(0, 0, 0)) == 'Class3(0, 0)'
+
+
+def test_qualname():
+    @repred(qualname=True)
+    class Class1:
+        def __init__(self):
+            ...
+
+    @repred(qualname=True)
+    class Class2:
+        def __init__(self, a, b, c=None):
+            self.a = a
+            self.b = b
+            self.c = c
+
+    assert repr(Class1()) == 'test_qualname.<locals>.Class1()'
+
+    assert repr(Class2(1, 2)) == 'test_qualname.<locals>.Class2(a=1, b=2)'
+    assert repr(Class2(1, 2, 3)) == 'test_qualname.<locals>.Class2(a=1, b=2, c=3)'
+    assert repr(Class2(1, 2, c=3)) == 'test_qualname.<locals>.Class2(a=1, b=2, c=3)'

--- a/tests/units/test_repred.py
+++ b/tests/units/test_repred.py
@@ -335,3 +335,25 @@ def test_qualname():
     assert repr(Class2(1, 2)) == 'test_qualname.<locals>.Class2(a=1, b=2)'
     assert repr(Class2(1, 2, 3)) == 'test_qualname.<locals>.Class2(a=1, b=2, c=3)'
     assert repr(Class2(1, 2, c=3)) == 'test_qualname.<locals>.Class2(a=1, b=2, c=3)'
+
+
+def test_wrong_filters():
+    with pytest.raises(ValueError, match=match('Keys for a filtered dictionary can be either integers starting from 0 or strings (parameter names).')):
+        @repred(filters={...: lambda x: x})
+        class SomeClass1: ...
+
+    with pytest.raises(ValueError, match=match('Keys for a filtered dictionary can be either integers starting from 0 or strings (parameter names).')):
+        @repred(filters={-1: lambda x: x})
+        class SomeClass2: ...
+
+    with pytest.raises(ValueError, match=match('Keys for a filtered dictionary can be either integers starting from 0 or strings (parameter names).')):
+        @repred(filters={'lol kek': lambda x: x})
+        class SomeClass3: ...
+
+    with pytest.raises(SignatureMismatchError, match=match('You have defined a getter for parameter "name" that cannot be called with a single argument.')):
+        @repred(filters={'name': lambda: False})
+        class SomeClass4: ...
+
+    with pytest.raises(SignatureMismatchError, match=match('You have defined a getter for parameter "0" that cannot be called with a single argument.')):
+        @repred(filters={0: lambda: False})
+        class SomeClass5: ...

--- a/tests/units/test_repred.py
+++ b/tests/units/test_repred.py
@@ -357,3 +357,11 @@ def test_wrong_filters():
     with pytest.raises(SignatureMismatchError, match=match('You have defined a getter for parameter "0" that cannot be called with a single argument.')):
         @repred(filters={0: lambda: False})
         class SomeClass5: ...
+
+
+def test_init_without_self():
+    with pytest.raises(ParameterMappingNotFoundError, match=match('It seems that the "self" argument was not found for the __init__ method of class SomeClass.')):
+        @repred
+        class SomeClass:
+            def __init__():
+                ...

--- a/tests/units/test_repred.py
+++ b/tests/units/test_repred.py
@@ -365,3 +365,17 @@ def test_init_without_self():
         class SomeClass:
             def __init__():
                 ...
+
+
+def test_ignore_wrong_identificator():
+    with pytest.raises(ValueError, match=match('You have specified the parameter name \'lol kek\' to ignore, which is not a valid identifier name in Python.')):
+        @repred(ignore=['lol kek'])
+        class SomeClass:
+            def __init__(self):
+                ...
+
+    with pytest.raises(NameError, match=match('Parameter "lol" is not used when initializing objects of class SomeClass2, but you have defined it as an ignored one.')):
+        @repred(ignore=['lol'])
+        class SomeClass2:
+            def __init__(self):
+                ...

--- a/tests/units/test_repred.py
+++ b/tests/units/test_repred.py
@@ -379,3 +379,38 @@ def test_ignore_wrong_identificator():
         class SomeClass2:
             def __init__(self):
                 ...
+
+
+def test_simple_ignore():
+    @repred(ignore=['args'])
+    class Class1:
+        def __init__(self, *args):
+            self.args = args
+
+    @repred(ignore=['kwargs'])
+    class Class2:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    @repred(ignore=['c'])
+    class Class3:
+        def __init__(self, a, b, c=None):
+            self.a = a
+            self.b = b
+            self.c = c
+
+    @repred(ignore=['a'])
+    class Class4:
+        def __init__(self, a, b, c=None):
+            self.a = a
+            self.b = b
+            self.c = c
+
+    assert repr(Class1()) == 'Class1()'
+    assert repr(Class1(1, 2, 3)) == 'Class1()'
+
+    assert repr(Class2(a=1, b=2, c=3)) == 'Class2()'
+
+    assert repr(Class3(a=1, b=2, c=3)) == 'Class3(a=1, b=2)'
+
+    assert repr(Class4(a=1, b=2, c=3)) == 'Class4(b=2, c=3)'

--- a/tests/units/test_repred.py
+++ b/tests/units/test_repred.py
@@ -273,3 +273,45 @@ def test_star_kwargs():
     assert repr(Class3(1, 2, 3)) == 'Class3(1, 2, 3)'
     assert repr(Class3(1, 2, c=3)) == 'Class3(1, 2, 3)'
     assert repr(Class3(1, 2, 3, d=4, e=5)) == 'Class3(1, 2, 3, d=4, e=5)'
+
+
+def test_set_filters():
+    @repred(filters={'x': lambda x: x})
+    class Class1:
+        def __init__(self, x, y):
+            self.x = x
+            self.y = y
+
+    assert repr(Class1(0, 0)) == 'Class1(y=0)'
+
+    @repred(
+        filters={1: lambda x: x},
+        prefer_positional=True,
+    )
+    class Class2:
+        def __init__(self, x, y):
+            self.x = x
+            self.y = y
+
+
+    assert repr(Class2(0, 0)) == 'Class2(0)'
+
+    @repred(
+        filters={0: lambda x: x},
+        prefer_positional=True,
+    )
+    class Class3:
+        def __init__(self, *args):
+            self.x = args
+
+    assert repr(Class3(0, 0, 0)) == 'Class3(0, 0)'
+
+    @repred(
+        filters={0: lambda x: x},
+        prefer_positional=True,
+    )
+    class Class4:
+        def __init__(self, *args):
+            self.x = args
+
+    assert repr(Class3(0, 0, 0)) == 'Class3(0, 0)'


### PR DESCRIPTION
A small but important update:

- You can now pass dictionaries containing filters and lists of ignored parameters to the `@repred` decorator.
- You can now also configure the `@repred` decorator to use the class's `__qualname__` attribute instead of `__name__`.
- The test suite slightly improved.