### PR TITLE
0.0.24

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Pythonistas follow an implicit convention to create special [`__repr__`](https:/
 - [**Filtering**](#filtering)
 - [**Custom display of objects**](#custom-display-of-objects)
 - [**Placeholders**](#placeholders)
+- [**Output limits**](#output-limits)
 - [**Auto mode**](#auto-mode)
 
 
@@ -169,6 +170,41 @@ print(
 > 🤓 If you set a placeholder for a parameter, the [custom serializer](#custom-display-of-objects) will not be applied to it.
 
 
+## Output limits
+
+You can limit the length of individual serialized values with `item_limit`, and the total length of the output string with `total_limit`. Both are disabled by default (`None`).
+
+`item_limit` truncates each serialized value to at most `N` characters, appending `...` if the value is longer:
+
+```python
+print(
+    describe_data_object(
+        'MyClass',
+        (123456789,),
+        {'name': 'a very long string'},
+        item_limit=5,
+    )
+)
+#> MyClass(12345..., name='a v'...)
+```
+
+`total_limit` limits the total length of the output. If the output would be too long, whole items are dropped from the right and replaced with `...`:
+
+```python
+print(
+    describe_data_object(
+        'MyClass',
+        (),
+        {'a': 1, 'b': 2, 'c': 3},
+        total_limit=20,
+    )
+)
+#> MyClass(a=1, ...)
+```
+
+If `total_limit` is too small to fit even `ClassName(...)`, a `ValueError` is raised. The minimum valid value is `len(class_name) + 5`.
+
+
 ## Auto mode
 
 > ⚠️ Auto mode is currently experimental, so there may be some bugs.
@@ -196,6 +232,19 @@ print(SomeClass(1, 2, 3, 4, 5, d=lambda x: x))
 ```
 
 How does it work? Behind the scenes, the decorator uses AST analysis to generate code. The decorator attempts to determine which arguments passed to `__init__` are stored in which attributes. In other words, it looks for direct assignments of the form `self.a = a` in the `__init__` method.
+
+Conditional (ternary) assignments are also recognized. If you write `self.a = a if a else default`, the decorator understands that parameter `a` is stored in attribute `a`:
+
+```python
+@repred
+class SomeClass:
+    def __init__(self, a, b):
+        self.a = a if a is not None else 0
+        self.b = b
+
+print(SomeClass(42, 'hello'))
+#> SomeClass(a=42, b='hello')
+```
 
 If there is no *direct assignment* of a specific argument, an exception will be raised:
 

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ print(
         item_limit=5,
     )
 )
-#> MyClass(12345..., name='a v'...)
+#> MyClass(12345..., name='a ver'...)
 ```
 
 `total_limit` limits the total length of the output. If the output would be too long, whole items are dropped from the right and replaced with `...`:
@@ -196,7 +196,7 @@ print(
         'MyClass',
         (),
         {'a': 1, 'b': 2, 'c': 3},
-        total_limit=20,
+        total_limit=15,
     )
 )
 #> MyClass(a=1, ...)

--- a/printo/__init__.py
+++ b/printo/__init__.py
@@ -4,6 +4,7 @@ from printo.describe import (
 from printo.describe import (
     descript_data_object as descript_data_object,
 )
+from printo.errors import AmbiguousMappingError as AmbiguousMappingError
 from printo.errors import CanNotBePositionalError as CanNotBePositionalError
 from printo.errors import ParameterMappingNotFoundError as ParameterMappingNotFoundError
 from printo.errors import RedefinitionError as RedefinitionError

--- a/printo/describe.py
+++ b/printo/describe.py
@@ -3,6 +3,59 @@ from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
 from printo.reprs import superrepr
 
 
+def _truncate_string_repr(value: str, item_limit: int) -> str:
+    if len(repr('')) > item_limit:
+        return repr(value)[:item_limit] + '...'
+    lo, hi = 0, len(value)
+    while lo < hi:
+        mid = (lo + hi + 1) // 2
+        if len(repr(value[:mid])) <= item_limit:
+            lo = mid
+        else:
+            hi = mid - 1
+    return repr(value[:lo]) + '...'
+
+
+def _serialize_item(  # noqa: PLR0913
+    key: Union[str, int],
+    value: Any,
+    filters: Dict[Union[str, int], Callable[[Any], bool]],
+    get_placeholder: Callable[[Union[str, int]], Optional[str]],
+    serializer: Callable[[Any], str],
+    item_limit: Optional[int],
+) -> Optional[str]:
+    from sigmatch import PossibleCallMatcher  # noqa: PLC0415
+
+    decider = filters.get(key, lambda x: True)  # noqa: ARG005
+    PossibleCallMatcher('.').match(decider, raise_exception=True)
+    if not decider(value):
+        return None
+    placeholder = get_placeholder(key)
+    serialized = placeholder if placeholder is not None else serializer(value)
+    if item_limit is not None and len(serialized) > item_limit:
+        if placeholder is None and isinstance(value, str) and serialized == repr(value):
+            serialized = _truncate_string_repr(value, item_limit)
+        else:
+            serialized = serialized[:item_limit] + '...'
+    return serialized
+
+
+def _serialize_items(  # noqa: PLR0913
+    items: Iterable[Tuple[Union[str, int], Any]],
+    format_chunk: Callable[[Union[str, int], str], str],
+    filters: Dict[Union[str, int], Callable[[Any], bool]],
+    get_placeholder: Callable[[Union[str, int]], Optional[str]],
+    serializer: Callable[[Any], str],
+    item_limit: Optional[int],
+) -> List[str]:
+    chunks = []
+    for key, value in items:
+        result = _serialize_item(key, value, filters, get_placeholder, serializer, item_limit)
+        if result is not None:
+            chunks.append(format_chunk(key, result))
+    return chunks
+
+
 def describe_data_object(  # noqa: PLR0913
     class_name: str,
     args: Union[Tuple[Any, ...], List[Any]],
@@ -10,46 +63,48 @@ def describe_data_object(  # noqa: PLR0913
     serializer: Callable[[Any], str] = superrepr,
     filters: Optional[Dict[Union[str, int], Callable[[Any], bool]]] = None,
     placeholders: Optional[Dict[Union[str, int], str]] = None,
+    item_limit: Optional[int] = None,
+    total_limit: Optional[int] = None,
 ) -> str:
     from sigmatch import PossibleCallMatcher  # noqa: PLC0415
 
     PossibleCallMatcher('.').match(serializer, raise_exception=True)
+
+    if item_limit is not None and item_limit < 0:
+        raise ValueError(f'item_limit must be a non-negative integer, got {item_limit}.')
+
+    if total_limit is not None:
+        if total_limit < 0:
+            raise ValueError(f'total_limit must be a non-negative integer, got {total_limit}.')
+        minimum = len(class_name) + 5
+        if total_limit < minimum:
+            raise ValueError(
+                f'total_limit ({total_limit}) is too small for class name {class_name!r}. '
+                f'Minimum is {minimum} (class name length + 5 for parentheses and ellipsis).',
+            )
 
     real_filters: Dict[Union[str, int], Callable[[Any], bool]] = (
         filters if filters is not None else {}
     )
     get_placeholder: Callable[[Union[str, int]], Optional[str]] = lambda field_name: placeholders.get(field_name) if placeholders is not None else None
 
-    def serialize_item(
-        key: Union[str, int],
-        value: Any,
-    ) -> Optional[str]:
-        decider = real_filters.get(key, lambda x: True)  # noqa: ARG005
-        PossibleCallMatcher('.').match(decider, raise_exception=True)
-        if not decider(value):
-            return None
-        placeholder = get_placeholder(key)
-        return placeholder if placeholder is not None else serializer(value)
+    args_chunks = _serialize_items(enumerate(args), lambda _, value: value, real_filters, get_placeholder, serializer, item_limit)
+    kwargs_chunks = _serialize_items(kwargs.items(), lambda key, value: f'{key}={value}', real_filters, get_placeholder, serializer, item_limit)
 
-    def serialize_items(
-        items: Iterable[Tuple[Union[str, int], Any]],
-        format_chunk: Callable[[Union[str, int], str], str],
-    ) -> str:
-        chunks = []
-        for key, value in items:
-            result = serialize_item(key, value)
-            if result is not None:
-                chunks.append(format_chunk(key, result))
-        return ', '.join(chunks)
+    all_chunks = args_chunks + kwargs_chunks
 
-    args_description = serialize_items(enumerate(args), lambda _, value: value)
-    kwargs_description = serialize_items(kwargs.items(), lambda key, value: f'{key}={value}')
+    full_output = f'{class_name}({", ".join(all_chunks)})'
 
-    breackets_content = ', '.join(
-        [x for x in (args_description, kwargs_description) if x],
-    )
+    if total_limit is not None and len(full_output) > total_limit:
+        for k in range(len(all_chunks) - 1, -1, -1):
+            if k == 0:
+                candidate = f'{class_name}(...)'
+            else:
+                candidate = f'{class_name}({", ".join(all_chunks[:k])}, ...)'
+            if len(candidate) <= total_limit:
+                return candidate
 
-    return f'{class_name}({breackets_content})'
+    return full_output
 
 
 descript_data_object = describe_data_object

--- a/printo/describe.py
+++ b/printo/describe.py
@@ -3,19 +3,6 @@ from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
 from printo.reprs import superrepr
 
 
-def _truncate_string_repr(value: str, item_limit: int) -> str:
-    if len(repr('')) > item_limit:
-        return repr(value)[:item_limit] + '...'
-    lo, hi = 0, len(value)
-    while lo < hi:
-        mid = (lo + hi + 1) // 2
-        if len(repr(value[:mid])) <= item_limit:
-            lo = mid
-        else:
-            hi = mid - 1
-    return repr(value[:lo]) + '...'
-
-
 def _serialize_item(  # noqa: PLR0913
     key: Union[str, int],
     value: Any,
@@ -32,10 +19,16 @@ def _serialize_item(  # noqa: PLR0913
         return None
     placeholder = get_placeholder(key)
     serialized = placeholder if placeholder is not None else serializer(value)
-    if item_limit is not None and len(serialized) > item_limit:
-        if placeholder is None and isinstance(value, str) and serialized == repr(value):
-            serialized = _truncate_string_repr(value, item_limit)
-        else:
+    if item_limit is not None:
+        if placeholder is not None:
+            if len(serialized) > item_limit:
+                serialized = serialized[:item_limit] + '...'
+        elif value is ...:
+            pass  # Ellipsis is never truncated
+        elif isinstance(value, (str, bytes)) and serialized == repr(value):
+            if len(value) > item_limit:
+                serialized = repr(value[:item_limit]) + '...'
+        elif len(serialized) > item_limit:
             serialized = serialized[:item_limit] + '...'
     return serialized
 
@@ -47,13 +40,15 @@ def _serialize_items(  # noqa: PLR0913
     get_placeholder: Callable[[Union[str, int]], Optional[str]],
     serializer: Callable[[Any], str],
     item_limit: Optional[int],
-) -> List[str]:
-    chunks = []
+) -> Tuple[List[str], List[bool]]:
+    chunks: List[str] = []
+    pinned: List[bool] = []
     for key, value in items:
         result = _serialize_item(key, value, filters, get_placeholder, serializer, item_limit)
         if result is not None:
             chunks.append(format_chunk(key, result))
-    return chunks
+            pinned.append(value is ...)
+    return chunks, pinned
 
 
 def describe_data_object(  # noqa: PLR0913
@@ -76,11 +71,11 @@ def describe_data_object(  # noqa: PLR0913
     if total_limit is not None:
         if total_limit < 0:
             raise ValueError(f'total_limit must be a non-negative integer, got {total_limit}.')
-        minimum = len(class_name) + 5
+        minimum = len(class_name) + 2
         if total_limit < minimum:
             raise ValueError(
                 f'total_limit ({total_limit}) is too small for class name {class_name!r}. '
-                f'Minimum is {minimum} (class name length + 5 for parentheses and ellipsis).',
+                f'Minimum is {minimum} (class name length + 2 for parentheses).',
             )
 
     real_filters: Dict[Union[str, int], Callable[[Any], bool]] = (
@@ -88,21 +83,35 @@ def describe_data_object(  # noqa: PLR0913
     )
     get_placeholder: Callable[[Union[str, int]], Optional[str]] = lambda field_name: placeholders.get(field_name) if placeholders is not None else None
 
-    args_chunks = _serialize_items(enumerate(args), lambda _, value: value, real_filters, get_placeholder, serializer, item_limit)
-    kwargs_chunks = _serialize_items(kwargs.items(), lambda key, value: f'{key}={value}', real_filters, get_placeholder, serializer, item_limit)
+    args_chunks, args_pinned = _serialize_items(enumerate(args), lambda _, value: value, real_filters, get_placeholder, serializer, item_limit)
+    kwargs_chunks, kwargs_pinned = _serialize_items(kwargs.items(), lambda key, value: f'{key}={value}', real_filters, get_placeholder, serializer, item_limit)
 
     all_chunks = args_chunks + kwargs_chunks
+    all_pinned = args_pinned + kwargs_pinned
 
     full_output = f'{class_name}({", ".join(all_chunks)})'
 
     if total_limit is not None and len(full_output) > total_limit:
-        for k in range(len(all_chunks) - 1, -1, -1):
-            if k == 0:
-                candidate = f'{class_name}(...)'
+        droppable = [i for i in range(len(all_chunks)) if not all_pinned[i]]
+        pinned_indices = [i for i in range(len(all_chunks)) if all_pinned[i]]
+
+        for num_keep in range(len(droppable) - 1, -1, -1):
+            kept_indices = sorted(pinned_indices + droppable[:num_keep])
+            kept_chunks = [all_chunks[i] for i in kept_indices]
+            if kept_chunks:
+                content = f'{class_name}({", ".join(kept_chunks)})'
+                output = f'{class_name}({", ".join(kept_chunks)}, ...)'
             else:
-                candidate = f'{class_name}({", ".join(all_chunks[:k])}, ...)'
-            if len(candidate) <= total_limit:
-                return candidate
+                content = f'{class_name}()'
+                output = f'{class_name}(...)'
+            if len(content) <= total_limit:
+                return output
+
+        # Ellipsis exemption: all droppable dropped, return pinned-only output regardless of limit
+        pinned_chunks = [all_chunks[i] for i in pinned_indices]
+        if not droppable:
+            return full_output
+        return f'{class_name}({", ".join(pinned_chunks)}, ...)'
 
     return full_output
 

--- a/printo/errors.py
+++ b/printo/errors.py
@@ -8,3 +8,7 @@ class ParameterMappingNotFoundError(Exception):
 
 class CanNotBePositionalError(Exception):
     ...
+
+
+class AmbiguousMappingError(Exception):
+    ...

--- a/printo/repred.py
+++ b/printo/repred.py
@@ -1,4 +1,4 @@
-from ast import Assign, Attribute, Name, parse
+from ast import Assign, Attribute, IfExp, Name, parse
 from functools import partial
 from inspect import Parameter, Signature, getattr_static, isclass, signature
 from typing import (
@@ -44,8 +44,15 @@ def get_mapping(cls: ClassType) -> Dict[str, str]:
 
     results = {}
     for node in tree.body[0].body:  # type: ignore[attr-defined]
-        if isinstance(node, Assign) and len(node.targets) == 1 and isinstance(node.targets[0], Attribute) and isinstance(node.targets[0].value, Name) and node.targets[0].value.id == self_name and isinstance(node.value, Name):
-            results[node.value.id] = node.targets[0].attr
+        if isinstance(node, Assign) and len(node.targets) == 1 and isinstance(node.targets[0], Attribute) and isinstance(node.targets[0].value, Name) and node.targets[0].value.id == self_name:
+            attr_name = node.targets[0].attr
+            if isinstance(node.value, Name):
+                results[node.value.id] = attr_name
+            elif isinstance(node.value, IfExp):
+                for branch in (node.value.body, node.value.orelse):
+                    if isinstance(branch, Name) and branch.id != self_name:
+                        results[branch.id] = attr_name
+                        break
 
     return results
 

--- a/printo/repred.py
+++ b/printo/repred.py
@@ -8,6 +8,7 @@ from typing import (
     Iterable,
     List,
     Optional,
+    Tuple,
     Type,
     TypeVar,
     Union,
@@ -19,6 +20,7 @@ from getsources import getclearsource
 
 from printo import describe_data_object
 from printo.errors import (
+    AmbiguousMappingError,
     CanNotBePositionalError,
     ParameterMappingNotFoundError,
     RedefinitionError,
@@ -26,11 +28,11 @@ from printo.errors import (
 
 ClassType = TypeVar('ClassType', bound=Type[Any])
 
-def get_mapping(cls: ClassType) -> Dict[str, str]:
+def get_mapping(cls: ClassType) -> Tuple[Dict[str, str], List[Tuple[str, str, str]]]:
     try:
         source = getclearsource(cls.__init__)
     except TypeError:
-        return {}
+        return {}, []
 
     tree = parse(source)
 
@@ -42,19 +44,30 @@ def get_mapping(cls: ClassType) -> Dict[str, str]:
         except IndexError as e:
             raise ParameterMappingNotFoundError(f'It seems that the "self" argument was not found for the __init__ method of class {cls.__name__}.') from e
 
-    results = {}
+    results: Dict[str, str] = {}
+    ambiguities: List[Tuple[str, str, str]] = []
     for node in tree.body[0].body:  # type: ignore[attr-defined]
         if isinstance(node, Assign) and len(node.targets) == 1 and isinstance(node.targets[0], Attribute) and isinstance(node.targets[0].value, Name) and node.targets[0].value.id == self_name:
             attr_name = node.targets[0].attr
             if isinstance(node.value, Name):
                 results[node.value.id] = attr_name
             elif isinstance(node.value, IfExp):
-                for branch in (node.value.body, node.value.orelse):
-                    if isinstance(branch, Name) and branch.id != self_name:
-                        results[branch.id] = attr_name
-                        break
+                if isinstance(node.value.body, IfExp) or isinstance(node.value.orelse, IfExp):
+                    pass  # Nested ternaries are not supported — skip
+                else:
+                    body_is_param = isinstance(node.value.body, Name) and node.value.body.id != self_name
+                    orelse_is_param = isinstance(node.value.orelse, Name) and node.value.orelse.id != self_name
+                    if body_is_param and orelse_is_param and node.value.body.id != node.value.orelse.id:  # type: ignore[attr-defined]
+                        ambiguities.append((node.value.body.id, node.value.orelse.id, attr_name))  # type: ignore[attr-defined]
+                    elif body_is_param and orelse_is_param:
+                        # Both branches are the same parameter — not ambiguous
+                        results[node.value.body.id] = attr_name  # type: ignore[attr-defined]
+                    elif body_is_param:
+                        results[node.value.body.id] = attr_name  # type: ignore[attr-defined]
+                    elif orelse_is_param:
+                        results[node.value.orelse.id] = attr_name  # type: ignore[attr-defined]
 
-    return results
+    return results, ambiguities
 
 
 @overload
@@ -113,7 +126,19 @@ def repred(cls: Optional[ClassType] = None, prefer_positional: bool = False, qua
         positionals = []
     positionals_to_compare = set(positionals)
 
-    names_mapping = get_mapping(cls)
+    names_mapping, ambiguities = get_mapping(cls)
+
+    for param1, param2, attr_name in ambiguities:
+        unresolved = [
+            parameter_name for parameter_name in (param1, param2)
+            if parameter_name not in default_getters and parameter_name not in ignored_parameters
+        ]
+        if unresolved:
+            raise AmbiguousMappingError(
+                f'Ternary expression in assignment to self.{attr_name} uses two different parameters '
+                f'({param1}, {param2}), making it ambiguous which parameter value will be stored. '
+                f'Provide custom getters for both parameters to resolve this.',
+            )
 
     positional_getters = {}
     keyword_getters = {}

--- a/printo/reprs.py
+++ b/printo/reprs.py
@@ -12,7 +12,7 @@ def superrepr(value: Any) -> str:  # noqa: PLR0911
         if result == '<lambda>':
             try:
                 return getclearsource(value)
-            except UncertaintyWithLambdasError:
+            except (UncertaintyWithLambdasError, OSError):
                 return 'λ'
 
         return result

--- a/printo/reprs.py
+++ b/printo/reprs.py
@@ -30,4 +30,10 @@ def superrepr(value: Any) -> str:  # noqa: PLR0911
         parts.extend(f'{k}={superrepr(v)}' for k, v in value.keywords.items())
         return f'functools.partial({", ".join(parts)})'
 
-    return repr(value)
+    try:
+        return repr(value)
+    except Exception:  # noqa: BLE001
+        try:
+            return f'<{type(value).__name__}>'
+        except Exception:  # noqa: BLE001
+            return '<unprintable>'

--- a/printo/reprs.py
+++ b/printo/reprs.py
@@ -34,6 +34,6 @@ def superrepr(value: Any) -> str:  # noqa: PLR0911
         return repr(value)
     except Exception:  # noqa: BLE001
         try:
-            return f'<{type(value).__name__}>'
+            return f"<{type(value).__name__}'s object>"
         except Exception:  # noqa: BLE001
             return '<unprintable>'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = 'setuptools.build_meta'
 
 [project]
 name = 'printo'
-version = '0.0.23'
+version = '0.0.24'
 authors = [
   { name='Evgeniy Blinov', email='zheni-b@yandex.ru' },
 ]

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,4 +6,4 @@ mypy==1.14.1
 ruff==0.14.6
 mutmut==3.2.3
 full_match==0.0.3
-suby==0.0.8
+suby==0.0.9

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,3 +6,4 @@ mypy==1.14.1
 ruff==0.14.6
 mutmut==3.2.3
 full_match==0.0.3
+suby==0.0.8

--- a/tests/documentation/test_readme.py
+++ b/tests/documentation/test_readme.py
@@ -58,3 +58,33 @@ def test_placeholders():
             'variable_name': '***',
         },
     ) == "MySuperClass(1, ***, 'lol', variable_name=***, second_variable_name='kek')"
+
+
+def test_item_limit():
+    assert describe_data_object(
+        'MyClass',
+        (123456789,),
+        {'name': 'a very long string'},
+        item_limit=5,
+    ) == "MyClass(12345..., name='a v'...)"
+
+
+def test_total_limit():
+    assert describe_data_object(
+        'MyClass',
+        (),
+        {'a': 1, 'b': 2, 'c': 3},
+        total_limit=20,
+    ) == 'MyClass(a=1, ...)'
+
+
+def test_repred_conditional_expression():
+    from printo import repred  # noqa: PLC0415
+
+    @repred
+    class SomeClass:
+        def __init__(self, a: int, b: str) -> None:
+            self.a = a if a is not None else 0
+            self.b = b
+
+    assert repr(SomeClass(42, 'hello')) == "SomeClass(a=42, b='hello')"

--- a/tests/documentation/test_readme.py
+++ b/tests/documentation/test_readme.py
@@ -66,7 +66,7 @@ def test_item_limit():
         (123456789,),
         {'name': 'a very long string'},
         item_limit=5,
-    ) == "MyClass(12345..., name='a v'...)"
+    ) == "MyClass(12345..., name='a ver'...)"
 
 
 def test_total_limit():
@@ -74,7 +74,7 @@ def test_total_limit():
         'MyClass',
         (),
         {'a': 1, 'b': 2, 'c': 3},
-        total_limit=20,
+        total_limit=15,
     ) == 'MyClass(a=1, ...)'
 
 

--- a/tests/units/test_describe.py
+++ b/tests/units/test_describe.py
@@ -264,3 +264,141 @@ def test_async_function_as_argument():
 
     assert describe_data_object('ClassName', (function,), {}) == 'ClassName(function)'
     assert describe_data_object('ClassName', (), {'function': function}) == 'ClassName(function=function)'
+
+
+def test_broken_repr_as_argument():
+    class BrokenRepr:
+        def __repr__(self):
+            raise RuntimeError("repr is broken")
+
+    broken = BrokenRepr()
+    assert describe_data_object('ClassName', (broken,), {}) == 'ClassName(<BrokenRepr>)'
+    assert describe_data_object('ClassName', (), {'x': broken}) == 'ClassName(x=<BrokenRepr>)'
+    assert describe_data_object('ClassName', (1, broken, 2), {'x': broken}) == 'ClassName(1, <BrokenRepr>, 2, x=<BrokenRepr>)'
+
+
+def test_item_limit_basic():
+    # superrepr(12345) = '12345' (5 chars); item_limit=2 -> '12...'
+    assert describe_data_object('C', (12345,), {}, item_limit=2) == 'C(12...)'
+    assert describe_data_object('C', (), {'x': 12345}, item_limit=2) == 'C(x=12...)'
+
+
+def test_item_limit_not_exceeded():
+    # '12345' has 5 chars; item_limit=5 -> no truncation
+    assert describe_data_object('C', (12345,), {}, item_limit=5) == 'C(12345)'
+    # item_limit=4 -> '1234...'
+    assert describe_data_object('C', (12345,), {}, item_limit=4) == 'C(1234...)'
+
+
+def test_item_limit_zero():
+    # item_limit=0 -> value fully replaced with '...'
+    assert describe_data_object('C', (12345,), {}, item_limit=0) == 'C(...)'
+    assert describe_data_object('C', (), {'x': 12345}, item_limit=0) == 'C(x=...)'
+
+
+def test_item_limit_with_kwargs():
+    # limit applies only to the value part, not to 'key=value' as a whole
+    assert describe_data_object('C', (), {'key': 12345}, item_limit=2) == 'C(key=12...)'
+
+
+def test_item_limit_negative():
+    with pytest.raises(ValueError, match='item_limit must be a non-negative integer'):
+        describe_data_object('C', (1,), {}, item_limit=-1)
+
+
+def test_item_limit_with_placeholder():
+    # item_limit applies to placeholder strings too
+    assert describe_data_object('C', (1,), {}, item_limit=2, placeholders={0: 'secret'}) == 'C(se...)'
+
+
+def test_total_limit_basic():
+    # 'C(a=1, b=2, c=3)' = 16 chars; total_limit=11 -> 'C(a=1, ...)' = 11 chars
+    assert describe_data_object('C', (), {'a': 1, 'b': 2, 'c': 3}, total_limit=11) == 'C(a=1, ...)'
+
+
+def test_total_limit_not_exceeded():
+    result = describe_data_object('C', (1, 2), {}, total_limit=100)
+    assert result == 'C(1, 2)'
+    assert len(result) <= 100
+
+
+def test_total_limit_drops_to_ellipsis_only():
+    # First item doesn't fit — result is ClassName(...)
+    # 'Name(x=12345)' = 13 chars; total_limit=9 = minimum for 'Name' -> 'Name(...)'
+    assert describe_data_object('Name', (), {'x': 12345}, total_limit=9) == 'Name(...)'
+
+
+def test_total_limit_minimum():
+    # Exactly len(class_name) + 5 is the minimum valid total_limit
+    name = 'A'
+    minimum = len(name) + 5  # = 6
+    result = describe_data_object(name, (1, 2, 3), {}, total_limit=minimum)
+    assert result == 'A(...)'
+    assert len(result) == minimum
+
+
+def test_total_limit_too_small():
+    with pytest.raises(ValueError, match='total_limit'):
+        describe_data_object('ClassName', (1,), {}, total_limit=5)
+
+
+def test_total_limit_negative():
+    with pytest.raises(ValueError, match='total_limit must be a non-negative integer'):
+        describe_data_object('C', (1,), {}, total_limit=-1)
+
+
+def test_total_limit_with_item_limit():
+    # item_limit=2 truncates '12345' -> '12...', '1' stays as '1'
+    # chunks: ['a=1', 'b=12...'] -> full: 'C(a=1, b=12...)' = 15 chars
+    # total_limit=11: k=1 -> 'C(a=1, ...)' = 11 chars <= 11 ✓
+    assert describe_data_object('C', (), {'a': 1, 'b': 12345}, item_limit=2, total_limit=11) == 'C(a=1, ...)'
+
+
+def test_total_limit_first_item_too_long():
+    # First and only item exceeds total_limit -> 'C(...)'
+    # 'C(a=12345)' = 10 chars; total_limit=6 = minimum -> 'C(...)'
+    assert describe_data_object('C', (), {'a': 12345}, total_limit=6) == 'C(...)'
+
+
+def test_total_limit_exact_fit():
+    # 'A(1, 2, 3)' = 10 chars; total_limit=10 -> no truncation
+    result = describe_data_object('A', (1, 2, 3), {})
+    assert result == 'A(1, 2, 3)'
+    assert describe_data_object('A', (1, 2, 3), {}, total_limit=len(result)) == result
+
+
+def test_item_limit_string_basic():
+    # repr('hello world') = "'hello world'" = 13 chars; item_limit=7
+    # N=5: repr('hello') = "'hello'" = 7 chars <= 7; N=6: repr('hello ') = 8 > 7
+    assert describe_data_object('C', ('hello world',), {}, item_limit=7) == "C('hello'...)"
+    assert describe_data_object('C', (), {'name': 'hello world'}, item_limit=7) == "C(name='hello'...)"
+
+
+def test_item_limit_string_at_minimum():
+    # item_limit=2 fits only repr('') = "''" = 2 chars
+    assert describe_data_object('C', ('abc',), {}, item_limit=2) == "C(''...)"
+
+
+def test_item_limit_string_below_minimum():
+    # item_limit=1: repr('') = "''" = 2 > 1, so fall back to truncating the repr
+    # repr('abc') = "'abc'" -> first 1 char = "'" + '...' = "'..."
+    assert describe_data_object('C', ('abc',), {}, item_limit=1) == "C('...)"
+
+
+def test_item_limit_string_not_exceeded():
+    # repr('hi') = "'hi'" = 4 chars; item_limit=4 -> no truncation
+    assert describe_data_object('C', ('hi',), {}, item_limit=4) == "C('hi')"
+    # item_limit=5 -> still no truncation
+    assert describe_data_object('C', ('hi',), {}, item_limit=5) == "C('hi')"
+
+
+def test_item_limit_string_with_escape_chars():
+    # repr('a\nb') = "'a\\nb'" = 6 chars; item_limit=5
+    # N=2: repr('a\n') = "'a\\n'" = 5 chars <= 5; N=3: repr('a\nb') = 6 > 5
+    assert describe_data_object('C', ('a\nb',), {}, item_limit=5) == "C('a\\n'...)"
+
+
+def test_item_limit_string_custom_serializer():
+    # Custom serializer: str(x) gives 'hello' (no quotes)
+    # 'hello' != repr('hello') = "'hello'", so old truncation applies
+    assert describe_data_object('C', ('hello',), {}, serializer=lambda x: str(x), item_limit=3) == 'C(hel...)'

--- a/tests/units/test_describe.py
+++ b/tests/units/test_describe.py
@@ -311,6 +311,11 @@ def test_item_limit_with_placeholder():
     assert describe_data_object('C', (1,), {}, item_limit=2, placeholders={0: 'secret'}) == 'C(se...)'
 
 
+def test_item_limit_with_placeholder_not_exceeded():
+    # placeholder shorter than item_limit — no truncation
+    assert describe_data_object('C', (1,), {}, item_limit=10, placeholders={0: 'ok'}) == 'C(ok)'
+
+
 def test_total_limit_basic():
     # 'C(a=1, b=2, c=3)' = 16 chars; total_limit=10
     # content 'C(a=1, b=2)' = 11 > 10; content 'C(a=1)' = 7 <= 10 -> output 'C(a=1, ...)'

--- a/tests/units/test_describe.py
+++ b/tests/units/test_describe.py
@@ -272,9 +272,9 @@ def test_broken_repr_as_argument():
             raise RuntimeError("repr is broken")
 
     broken = BrokenRepr()
-    assert describe_data_object('ClassName', (broken,), {}) == 'ClassName(<BrokenRepr>)'
-    assert describe_data_object('ClassName', (), {'x': broken}) == 'ClassName(x=<BrokenRepr>)'
-    assert describe_data_object('ClassName', (1, broken, 2), {'x': broken}) == 'ClassName(1, <BrokenRepr>, 2, x=<BrokenRepr>)'
+    assert describe_data_object('ClassName', (broken,), {}) == "ClassName(<BrokenRepr's object>)"
+    assert describe_data_object('ClassName', (), {'x': broken}) == "ClassName(x=<BrokenRepr's object>)"
+    assert describe_data_object('ClassName', (1, broken, 2), {'x': broken}) == "ClassName(1, <BrokenRepr's object>, 2, x=<BrokenRepr's object>)"
 
 
 def test_item_limit_basic():
@@ -312,8 +312,9 @@ def test_item_limit_with_placeholder():
 
 
 def test_total_limit_basic():
-    # 'C(a=1, b=2, c=3)' = 16 chars; total_limit=11 -> 'C(a=1, ...)' = 11 chars
-    assert describe_data_object('C', (), {'a': 1, 'b': 2, 'c': 3}, total_limit=11) == 'C(a=1, ...)'
+    # 'C(a=1, b=2, c=3)' = 16 chars; total_limit=10
+    # content 'C(a=1, b=2)' = 11 > 10; content 'C(a=1)' = 7 <= 10 -> output 'C(a=1, ...)'
+    assert describe_data_object('C', (), {'a': 1, 'b': 2, 'c': 3}, total_limit=10) == 'C(a=1, ...)'
 
 
 def test_total_limit_not_exceeded():
@@ -329,12 +330,13 @@ def test_total_limit_drops_to_ellipsis_only():
 
 
 def test_total_limit_minimum():
-    # Exactly len(class_name) + 5 is the minimum valid total_limit
+    # Minimum is len(class_name) + 2; the actual output 'A(...)' may be longer
     name = 'A'
-    minimum = len(name) + 5  # = 6
+    minimum = len(name) + 2  # = 3
     result = describe_data_object(name, (1, 2, 3), {}, total_limit=minimum)
     assert result == 'A(...)'
-    assert len(result) == minimum
+    # Output is longer than total_limit because '...' marker doesn't count
+    assert len(result) > minimum
 
 
 def test_total_limit_too_small():
@@ -368,37 +370,148 @@ def test_total_limit_exact_fit():
 
 
 def test_item_limit_string_basic():
-    # repr('hello world') = "'hello world'" = 13 chars; item_limit=7
-    # N=5: repr('hello') = "'hello'" = 7 chars <= 7; N=6: repr('hello ') = 8 > 7
-    assert describe_data_object('C', ('hello world',), {}, item_limit=7) == "C('hello'...)"
-    assert describe_data_object('C', (), {'name': 'hello world'}, item_limit=7) == "C(name='hello'...)"
+    # len('hello world') = 11 > 5; truncate to 5 raw chars -> repr('hello') + '...'
+    assert describe_data_object('C', ('hello world',), {}, item_limit=5) == "C('hello'...)"
+    assert describe_data_object('C', (), {'name': 'hello world'}, item_limit=5) == "C(name='hello'...)"
 
 
-def test_item_limit_string_at_minimum():
-    # item_limit=2 fits only repr('') = "''" = 2 chars
-    assert describe_data_object('C', ('abc',), {}, item_limit=2) == "C(''...)"
+def test_item_limit_string_exact_boundary():
+    # len('abc') = 3 == item_limit=3 -> no truncation
+    assert describe_data_object('C', ('abc',), {}, item_limit=3) == "C('abc')"
 
 
-def test_item_limit_string_below_minimum():
-    # item_limit=1: repr('') = "''" = 2 > 1, so fall back to truncating the repr
-    # repr('abc') = "'abc'" -> first 1 char = "'" + '...' = "'..."
-    assert describe_data_object('C', ('abc',), {}, item_limit=1) == "C('...)"
+def test_item_limit_string_one_over():
+    # len('abcd') = 4 > item_limit=3 -> repr('abc') + '...'
+    assert describe_data_object('C', ('abcd',), {}, item_limit=3) == "C('abc'...)"
+
+
+def test_item_limit_string_zero():
+    # item_limit=0: any non-empty string -> repr('') + '...' = "''" + '...'
+    assert describe_data_object('C', ('abc',), {}, item_limit=0) == "C(''...)"
 
 
 def test_item_limit_string_not_exceeded():
-    # repr('hi') = "'hi'" = 4 chars; item_limit=4 -> no truncation
-    assert describe_data_object('C', ('hi',), {}, item_limit=4) == "C('hi')"
-    # item_limit=5 -> still no truncation
-    assert describe_data_object('C', ('hi',), {}, item_limit=5) == "C('hi')"
+    # len('hi') = 2; item_limit=2 -> no truncation; item_limit=3 -> also no truncation
+    assert describe_data_object('C', ('hi',), {}, item_limit=2) == "C('hi')"
+    assert describe_data_object('C', ('hi',), {}, item_limit=3) == "C('hi')"
 
 
 def test_item_limit_string_with_escape_chars():
-    # repr('a\nb') = "'a\\nb'" = 6 chars; item_limit=5
-    # N=2: repr('a\n') = "'a\\n'" = 5 chars <= 5; N=3: repr('a\nb') = 6 > 5
-    assert describe_data_object('C', ('a\nb',), {}, item_limit=5) == "C('a\\n'...)"
+    # 'a\nb' has len=3 ('\n' is 1 raw char); item_limit=2 -> repr('a\n') + '...'
+    assert describe_data_object('C', ('a\nb',), {}, item_limit=2) == "C('a\\n'...)"
+
+
+def test_item_limit_string_kwargs():
+    # Truncation by raw length applies to kwargs values too
+    assert describe_data_object('C', (), {'name': 'abcdef'}, item_limit=2) == "C(name='ab'...)"
 
 
 def test_item_limit_string_custom_serializer():
-    # Custom serializer: str(x) gives 'hello' (no quotes)
-    # 'hello' != repr('hello') = "'hello'", so old truncation applies
+    # Custom serializer: result doesn't equal repr(value), so generic truncation applies
     assert describe_data_object('C', ('hello',), {}, serializer=lambda x: str(x), item_limit=3) == 'C(hel...)'
+
+
+def test_item_limit_bytes_basic():
+    # len(b'hello world') = 11 > 5; truncate to 5 raw bytes -> repr(b'hello') + '...'
+    assert describe_data_object('C', (b'hello world',), {}, item_limit=5) == "C(b'hello'...)"
+
+
+def test_item_limit_bytes_exact_boundary():
+    # len(b'abc') = 3 == item_limit=3 -> no truncation
+    assert describe_data_object('C', (b'abc',), {}, item_limit=3) == "C(b'abc')"
+
+
+def test_item_limit_bytes_one_over():
+    # len(b'abcd') = 4 > item_limit=3 -> repr(b'abc') + '...'
+    assert describe_data_object('C', (b'abcd',), {}, item_limit=3) == "C(b'abc'...)"
+
+
+def test_item_limit_bytes_zero():
+    # item_limit=0: any non-empty bytes -> repr(b'') + '...'
+    assert describe_data_object('C', (b'abc',), {}, item_limit=0) == "C(b''...)"
+
+
+def test_item_limit_bytes_with_non_ascii():
+    # Non-ASCII bytes: repr uses escape sequences, but limit counts raw bytes
+    # len(b'\xff\xfe') = 2; item_limit=1 -> repr(b'\xff') + '...'
+    assert describe_data_object('C', (b'\xff\xfe',), {}, item_limit=1) == "C(b'\\xff'...)"
+
+
+def test_item_and_chunk_truncation_coexist():
+    # item_limit truncates '123456' -> '12...'; total_limit then drops 'b=2' chunk
+    # chunks after item_limit: ['a=12...', 'b=2']; full = 'S(a=12..., b=2)' = 15
+    # total_limit=10: content 'S(a=12...)' = 10 <= 10 -> output 'S(a=12..., ...)'
+    result = describe_data_object('S', (), {'a': 123456, 'b': 2}, item_limit=2, total_limit=10)
+    assert result == 'S(a=12..., ...)'
+
+
+def test_chunk_truncation_preserves_comma():
+    # When k>0, output includes ', ...' (comma before ellipsis)
+    result = describe_data_object('C', (), {'a': 1, 'b': 2}, total_limit=7)
+    assert result == 'C(a=1, ...)'
+    assert ', ...' in result
+
+
+def test_chunk_truncation_no_comma_when_all_dropped():
+    # When all chunks dropped (k==0), output is 'ClassName(...)' without comma
+    result = describe_data_object('C', (), {'a': 12345}, total_limit=3)
+    assert result == 'C(...)'
+    assert ', ...' not in result
+
+
+def test_item_limit_ellipsis_not_truncated():
+    # Ellipsis value is never truncated by item_limit
+    assert describe_data_object('C', (...,), {}, item_limit=1) == 'C(Ellipsis)'
+    assert describe_data_object('C', (...,), {}, item_limit=0) == 'C(Ellipsis)'
+
+
+def test_item_limit_ellipsis_with_placeholder():
+    # Placeholder for Ellipsis is still subject to item_limit
+    assert describe_data_object('C', (...,), {}, item_limit=2, placeholders={0: 'secret'}) == 'C(se...)'
+
+
+def test_total_limit_output_longer_than_limit():
+    # '...' marker doesn't count toward total_limit, so output can exceed total_limit
+    # 'C(a=1)' = 7 chars <= total_limit=7; output = 'C(a=1, ...)' = 11 > 7
+    result = describe_data_object('C', (), {'a': 1, 'b': 2}, total_limit=7)
+    assert result == 'C(a=1, ...)'
+    assert len(result) > 7
+
+
+def test_total_limit_ellipsis_not_dropped():
+    # Ellipsis argument is never dropped by total_limit
+    # 'C(Ellipsis, x=1)' = 17 chars; small total_limit should drop 'x=1' but keep Ellipsis
+    result = describe_data_object('C', (...,), {'x': 1}, total_limit=13)
+    assert result == 'C(Ellipsis, ...)'
+
+
+def test_total_limit_ellipsis_other_items_dropped():
+    # Non-Ellipsis items are dropped before Ellipsis
+    # 'C(Ellipsis, 1, 2)' = 18 chars
+    # Drop '2': content = 'C(Ellipsis, 1)' = 14 chars
+    # Drop '1': content = 'C(Ellipsis)' = 11 chars
+    result = describe_data_object('C', (..., 1, 2), {}, total_limit=11)
+    assert result == 'C(Ellipsis, ...)'
+
+
+def test_total_limit_all_ellipsis():
+    # All arguments are Ellipsis — nothing can be dropped
+    # Even if content exceeds total_limit, return full output (Ellipsis exemption)
+    result = describe_data_object('C', (..., ...), {}, total_limit=3)
+    assert result == 'C(Ellipsis, Ellipsis)'
+
+
+def test_total_limit_ellipsis_pinned_content_exceeds_limit():
+    # Ellipsis + droppable item; even pinned-only content exceeds total_limit
+    # 'C(Ellipsis, 1)' = 14 > 3; drop '1': content 'C(Ellipsis)' = 11 > 3 -> fallback
+    # Returns pinned-only + '...' regardless of limit
+    result = describe_data_object('C', (..., 1), {}, total_limit=3)
+    assert result == 'C(Ellipsis, ...)'
+
+
+def test_total_limit_ellipsis_mixed_positions():
+    # Ellipsis in the middle — order preserved, non-Ellipsis dropped from the end
+    # 'C(1, Ellipsis, 2)' = 18 chars
+    # Drop '2': content = 'C(1, Ellipsis)' = 14 chars
+    result = describe_data_object('C', (1, ..., 2), {}, total_limit=14)
+    assert result == 'C(1, Ellipsis, ...)'

--- a/tests/units/test_repred.py
+++ b/tests/units/test_repred.py
@@ -10,6 +10,20 @@ from printo import (
 )
 
 
+def test_repred_with_broken_repr_attribute():
+    @repred
+    class SomeClass:
+        def __init__(self, value):
+            self.value = value
+
+    class BrokenRepr:
+        def __repr__(self):
+            raise RuntimeError("repr is broken")
+
+    result = repr(SomeClass(BrokenRepr()))
+    assert result == 'SomeClass(value=<BrokenRepr>)'
+
+
 def test_repred_with_async_function_value():
     @repred
     class SomeClass:
@@ -434,11 +448,77 @@ def test_simple_ignore():
 
 
 def test_conditional_expressions():
+    @repred
+    class SomeClass:
+        def __init__(self, a):
+            self.a = a if a else 123
+
+    # @repred reads self.a at repr time, which stores the result of the expression
+    assert repr(SomeClass(42)) == 'SomeClass(a=42)'
+    assert repr(SomeClass(0)) == 'SomeClass(a=123)'
+
+
+def test_conditional_expression_reversed():
+    @repred
+    class SomeClass:
+        def __init__(self, a):
+            self.a = 123 if not a else a  # noqa: SIM212
+
+    assert repr(SomeClass(42)) == 'SomeClass(a=42)'
+    assert repr(SomeClass(0)) == 'SomeClass(a=123)'
+
+
+def test_conditional_expression_with_default_value():
+    @repred
+    class SomeClass:
+        def __init__(self, a=None):
+            self.a = a if a is not None else 'default'
+
+    # When a=None (default), self.a stores 'default', which differs from default None -> shown
+    assert repr(SomeClass()) == "SomeClass(a='default')"
+    assert repr(SomeClass(42)) == 'SomeClass(a=42)'
+
+
+def test_conditional_expression_multiple_params():
+    @repred
+    class SomeClass:
+        def __init__(self, a, b, c):
+            self.a = a if a else 0
+            self.b = b
+            self.c = 'fallback' if not c else c  # noqa: SIM212
+
+    assert repr(SomeClass(1, 2, 3)) == 'SomeClass(a=1, b=2, c=3)'
+    # self.a = 0 if 0 else 0 = 0; self.c = 'fallback' if not 0 else 0 = 'fallback'
+    assert repr(SomeClass(0, 2, 0)) == "SomeClass(a=0, b=2, c='fallback')"
+
+
+def test_conditional_expression_not_recognized():
     with pytest.raises(ParameterMappingNotFoundError, match=match('No internal object property or custom getter was found for the parameter a.')):
         @repred
         class SomeClass:
             def __init__(self, a):
-                self.a = a if a else 123
+                self.a = str(a) if a else 'empty'
+
+
+def test_conditional_expression_nested():
+    @repred
+    class SomeClass:
+        def __init__(self, a, b):
+            self.a = a if a else (b if b else 0)
+            self.b = b
+
+    assert repr(SomeClass(1, 2)) == 'SomeClass(a=1, b=2)'
+
+
+def test_conditional_expression_both_branches_are_params():
+    @repred
+    class SomeClass:
+        def __init__(self, a, b):
+            self.x = a if True else b
+            self.b = b
+
+    # body=Name('a') takes priority; repr uses param name 'a', reads attr 'x'
+    assert repr(SomeClass(1, 2)) == 'SomeClass(a=1, b=2)'
 
 
 def test_set_wrong_positionals():

--- a/tests/units/test_repred.py
+++ b/tests/units/test_repred.py
@@ -3,6 +3,7 @@ from full_match import match
 from sigmatch import SignatureMismatchError
 
 from printo import (
+    AmbiguousMappingError,
     CanNotBePositionalError,
     ParameterMappingNotFoundError,
     RedefinitionError,
@@ -21,7 +22,7 @@ def test_repred_with_broken_repr_attribute():
             raise RuntimeError("repr is broken")
 
     result = repr(SomeClass(BrokenRepr()))
-    assert result == 'SomeClass(value=<BrokenRepr>)'
+    assert result == "SomeClass(value=<BrokenRepr's object>)"
 
 
 def test_repred_with_async_function_value():
@@ -501,24 +502,23 @@ def test_conditional_expression_not_recognized():
 
 
 def test_conditional_expression_nested():
-    @repred
-    class SomeClass:
-        def __init__(self, a, b):
-            self.a = a if a else (b if b else 0)
-            self.b = b
-
-    assert repr(SomeClass(1, 2)) == 'SomeClass(a=1, b=2)'
+    # orelse is IfExp -> nested ternary, not supported; self.a not mapped -> error
+    with pytest.raises(ParameterMappingNotFoundError, match=match('No internal object property or custom getter was found for the parameter a.')):
+        @repred
+        class SomeClass:
+            def __init__(self, a, b):
+                self.a = a if a else (b if b else 0)
+                self.b = b
 
 
 def test_conditional_expression_both_branches_are_params():
-    @repred
-    class SomeClass:
-        def __init__(self, a, b):
-            self.x = a if True else b
-            self.b = b
-
-    # body=Name('a') takes priority; repr uses param name 'a', reads attr 'x'
-    assert repr(SomeClass(1, 2)) == 'SomeClass(a=1, b=2)'
+    # Both branches are different params -> AmbiguousMappingError
+    with pytest.raises(AmbiguousMappingError):
+        @repred
+        class SomeClass:
+            def __init__(self, a, b):
+                self.x = a if True else b
+                self.b = b
 
 
 def test_set_wrong_positionals():
@@ -607,3 +607,102 @@ def test_positionals():
     assert repr(Class4(1, 2)) == 'Class4(1, 2)'
     assert repr(Class4(1, 2, 3)) == 'Class4(1, 2, 3)'
     assert repr(Class4(1, 2, c=3)) == 'Class4(1, 2, 3)'
+
+
+def test_ternary_ambiguity_basic():
+    with pytest.raises(AmbiguousMappingError, match=r'self\.x'):
+        @repred
+        class SomeClass:
+            def __init__(self, a, b):
+                self.x = a if True else b
+                self.b = b
+
+
+def test_ternary_ambiguity_resolved_by_getters():
+    @repred(getters={'a': lambda obj: obj.x, 'b': lambda obj: obj.x})
+    class SomeClass:
+        def __init__(self, a, b):
+            self.x = a if True else b
+
+    assert repr(SomeClass(1, 2)) == 'SomeClass(a=1, b=1)'
+
+
+def test_ternary_ambiguity_one_getter_missing():
+    with pytest.raises(AmbiguousMappingError):
+        @repred(getters={'a': lambda obj: obj.x})
+        class SomeClass:
+            def __init__(self, a, b):
+                self.x = a if True else b
+                self.b = b
+
+
+def test_ternary_ambiguity_one_ignored():
+    # One param ignored, the other has no getter -> still AmbiguousMappingError
+    with pytest.raises(AmbiguousMappingError):
+        @repred(ignore=['a'])
+        class SomeClass:
+            def __init__(self, a, b):
+                self.x = a if True else b
+                self.b = b
+
+
+def test_ternary_ambiguity_both_ignored():
+    @repred(ignore=['a', 'b'])
+    class SomeClass:
+        def __init__(self, a, b):
+            self.x = a if True else b
+
+    assert repr(SomeClass(1, 2)) == 'SomeClass()'
+
+
+def test_ternary_ambiguity_one_ignored_one_getter():
+    @repred(ignore=['a'], getters={'b': lambda obj: obj.x})
+    class SomeClass:
+        def __init__(self, a, b):
+            self.x = a if True else b
+
+    assert repr(SomeClass(1, 2)) == 'SomeClass(b=1)'
+
+
+def test_ternary_same_param_both_branches():
+    # self.a = a if cond else a — both branches same param, not ambiguous
+    @repred
+    class SomeClass:
+        def __init__(self, a):
+            self.a = a if a else a  # noqa: RUF034
+
+    assert repr(SomeClass(42)) == 'SomeClass(a=42)'
+    assert repr(SomeClass(0)) == 'SomeClass(a=0)'
+
+
+def test_nested_ternary_rejected():
+    # body is IfExp -> nested, not supported -> self.a not mapped -> ParameterMappingNotFoundError
+    with pytest.raises(ParameterMappingNotFoundError, match=match('No internal object property or custom getter was found for the parameter a.')):
+        @repred
+        class SomeClass:
+            def __init__(self, a, b, c):
+                self.a = (a if True else b) if True else c
+                self.b = b
+                self.c = c
+
+
+def test_nested_ternary_in_orelse():
+    # orelse is IfExp -> nested, not supported -> self.a not mapped -> ParameterMappingNotFoundError
+    with pytest.raises(ParameterMappingNotFoundError, match=match('No internal object property or custom getter was found for the parameter a.')):
+        @repred
+        class SomeClass:
+            def __init__(self, a, b, c):
+                self.a = a if True else (b if True else c)
+                self.b = b
+                self.c = c
+
+
+def test_nested_ternary_with_getter():
+    # Nested ternary + getter for the unmapped param -> works fine
+    @repred(getters={'a': lambda obj: obj.a})
+    class SomeClass:
+        def __init__(self, a, b):
+            self.a = a if True else (b if True else 0)
+            self.b = b
+
+    assert repr(SomeClass(1, 2)) == 'SomeClass(a=1, b=2)'

--- a/tests/units/test_repred.py
+++ b/tests/units/test_repred.py
@@ -706,3 +706,14 @@ def test_nested_ternary_with_getter():
             self.b = b
 
     assert repr(SomeClass(1, 2)) == 'SomeClass(a=1, b=2)'
+
+
+def test_init_with_non_name_non_ifexp_assignment():
+    # self.x = 42 is a Constant (not Name, not IfExp) — get_mapping skips it
+    @repred
+    class SomeClass:
+        def __init__(self, a):
+            self.x = 42
+            self.a = a
+
+    assert repr(SomeClass(1)) == 'SomeClass(a=1)'

--- a/tests/units/test_reprs.py
+++ b/tests/units/test_reprs.py
@@ -48,6 +48,7 @@ def test_superrepr_for_lambda_without_source_old_python():
         'from printo import superrepr; print(superrepr(lambda value, extra: False))',
         catch_output=True,
         split=False,
+        add_env={'PYTHONUTF8': '1'},
     )
 
     assert result.stdout.strip() == 'λ', f'stdout={result.stdout!r} stderr={result.stderr!r}'
@@ -62,6 +63,7 @@ def test_superrepr_for_lambda_without_source_new_python():
         'from printo import superrepr; print(superrepr(lambda value, extra: False))',
         catch_output=True,
         split=False,
+        add_env={'PYTHONUTF8': '1'},
     )
 
     assert result.stdout.strip() == 'lambda value, extra: False', f'stdout={result.stdout!r} stderr={result.stderr!r}'

--- a/tests/units/test_reprs.py
+++ b/tests/units/test_reprs.py
@@ -47,7 +47,7 @@ def test_superrepr_for_lambda_without_source():
         split=False,
     )
 
-    assert result.stdout.strip() == 'λ'
+    assert result.stdout.strip() == 'λ', f'stdout={result.stdout!r} stderr={result.stderr!r}'
 
 
 def test_superrepr_for_async_function():

--- a/tests/units/test_reprs.py
+++ b/tests/units/test_reprs.py
@@ -103,7 +103,7 @@ def test_superrepr_for_object_with_broken_repr():
         def __repr__(self):
             raise RuntimeError("repr is broken")
 
-    assert superrepr(BrokenRepr()) == "<BrokenRepr>"
+    assert superrepr(BrokenRepr()) == "<BrokenRepr's object>"
 
 
 def test_superrepr_for_object_with_repr_raising_different_exceptions():
@@ -123,10 +123,10 @@ def test_superrepr_for_object_with_repr_raising_different_exceptions():
         def __repr__(self):
             raise RecursionError("recursion error")
 
-    assert superrepr(RaisesValueError()) == "<RaisesValueError>"
-    assert superrepr(RaisesTypeError()) == "<RaisesTypeError>"
-    assert superrepr(RaisesAttributeError()) == "<RaisesAttributeError>"
-    assert superrepr(RaisesRecursionError()) == "<RaisesRecursionError>"
+    assert superrepr(RaisesValueError()) == "<RaisesValueError's object>"
+    assert superrepr(RaisesTypeError()) == "<RaisesTypeError's object>"
+    assert superrepr(RaisesAttributeError()) == "<RaisesAttributeError's object>"
+    assert superrepr(RaisesRecursionError()) == "<RaisesRecursionError's object>"
 
 
 def test_superrepr_for_object_with_broken_repr_and_broken_type():

--- a/tests/units/test_reprs.py
+++ b/tests/units/test_reprs.py
@@ -96,3 +96,47 @@ def test_superrepr_for_partial_with_class():
         pass
 
     assert superrepr(functools.partial(SomeClass)) == "functools.partial(SomeClass)"
+
+
+def test_superrepr_for_object_with_broken_repr():
+    class BrokenRepr:
+        def __repr__(self):
+            raise RuntimeError("repr is broken")
+
+    assert superrepr(BrokenRepr()) == "<BrokenRepr>"
+
+
+def test_superrepr_for_object_with_repr_raising_different_exceptions():
+    class RaisesValueError:
+        def __repr__(self):
+            raise ValueError("value error")
+
+    class RaisesTypeError:
+        def __repr__(self):
+            raise TypeError("type error")
+
+    class RaisesAttributeError:
+        def __repr__(self):
+            raise AttributeError("attr error")
+
+    class RaisesRecursionError:
+        def __repr__(self):
+            raise RecursionError("recursion error")
+
+    assert superrepr(RaisesValueError()) == "<RaisesValueError>"
+    assert superrepr(RaisesTypeError()) == "<RaisesTypeError>"
+    assert superrepr(RaisesAttributeError()) == "<RaisesAttributeError>"
+    assert superrepr(RaisesRecursionError()) == "<RaisesRecursionError>"
+
+
+def test_superrepr_for_object_with_broken_repr_and_broken_type():
+    class BrokenMeta(type):
+        @property
+        def __name__(cls):
+            raise RuntimeError("name is broken")
+
+    class BrokenEverything(metaclass=BrokenMeta):
+        def __repr__(self):
+            raise RuntimeError("repr is broken")
+
+    assert superrepr(BrokenEverything()) == "<unprintable>"

--- a/tests/units/test_reprs.py
+++ b/tests/units/test_reprs.py
@@ -1,5 +1,7 @@
 import functools
+import sys
 
+import pytest
 from suby import run  # type: ignore[import-not-found]
 
 from printo.reprs import superrepr
@@ -37,9 +39,10 @@ def test_superrepr_for_lambda_functions_when_they_are_multple_in_one_line():
     assert superrepr(lambdas[1]) == "λ"
 
 
-def test_superrepr_for_lambda_without_source():
-    # A lambda defined via python -c has no retrievable source file.
-    # superrepr must return 'λ' instead of raising OSError.
+@pytest.mark.skipif(sys.version_info >= (3, 13), reason='Python 3.13+ can introspect -c lambdas')
+def test_superrepr_for_lambda_without_source_old_python():
+    # On Python < 3.13, source of a lambda defined in -c is not retrievable.
+    # getclearsource raises OSError, and superrepr must fall back to 'λ'.
     result = run(
         'python3', '-c',
         'from printo import superrepr; print(superrepr(lambda value, extra: False))',
@@ -48,6 +51,20 @@ def test_superrepr_for_lambda_without_source():
     )
 
     assert result.stdout.strip() == 'λ', f'stdout={result.stdout!r} stderr={result.stderr!r}'
+
+
+@pytest.mark.skipif(sys.version_info < (3, 13), reason='Python < 3.13 cannot introspect -c lambdas')
+def test_superrepr_for_lambda_without_source_new_python():
+    # On Python 3.13+, source introspection for -c lambdas works,
+    # so superrepr returns the actual source code.
+    result = run(
+        'python3', '-c',
+        'from printo import superrepr; print(superrepr(lambda value, extra: False))',
+        catch_output=True,
+        split=False,
+    )
+
+    assert result.stdout.strip() == 'lambda value, extra: False', f'stdout={result.stdout!r} stderr={result.stderr!r}'
 
 
 def test_superrepr_for_async_function():

--- a/tests/units/test_reprs.py
+++ b/tests/units/test_reprs.py
@@ -44,7 +44,7 @@ def test_superrepr_for_lambda_without_source_old_python():
     # On Python < 3.13, source of a lambda defined in -c is not retrievable.
     # getclearsource raises OSError, and superrepr must fall back to 'λ'.
     result = run(
-        'python3', '-c',
+        sys.executable, '-c',
         'from printo import superrepr; print(superrepr(lambda value, extra: False))',
         catch_output=True,
         split=False,
@@ -58,7 +58,7 @@ def test_superrepr_for_lambda_without_source_new_python():
     # On Python 3.13+, source introspection for -c lambdas works,
     # so superrepr returns the actual source code.
     result = run(
-        'python3', '-c',
+        sys.executable, '-c',
         'from printo import superrepr; print(superrepr(lambda value, extra: False))',
         catch_output=True,
         split=False,

--- a/tests/units/test_reprs.py
+++ b/tests/units/test_reprs.py
@@ -2,7 +2,7 @@ import functools
 import sys
 
 import pytest
-from suby import run  # type: ignore[import-not-found]
+from suby import run
 
 from printo.reprs import superrepr
 

--- a/tests/units/test_reprs.py
+++ b/tests/units/test_reprs.py
@@ -1,5 +1,7 @@
 import functools
 
+from suby import run  # type: ignore[import-not-found]
+
 from printo.reprs import superrepr
 
 
@@ -33,6 +35,19 @@ def test_superrepr_for_lambda_functions_when_they_are_multple_in_one_line():
 
     assert superrepr(lambdas[0]) == "λ"
     assert superrepr(lambdas[1]) == "λ"
+
+
+def test_superrepr_for_lambda_without_source():
+    # A lambda defined via python -c has no retrievable source file.
+    # superrepr must return 'λ' instead of raising OSError.
+    result = run(
+        'python3', '-c',
+        'from printo import superrepr; print(superrepr(lambda value, extra: False))',
+        catch_output=True,
+        split=False,
+    )
+
+    assert result.stdout.strip() == 'λ'
 
 
 def test_superrepr_for_async_function():


### PR DESCRIPTION
A small but useful update. It mainly focuses on clarifying various edge cases for features added previously.

- The command `python3 -c "from printo import superrepr; print(superrepr(lambda value, extra: False))"` now always correctly outputs either the `λ` symbol or the full lambda function code.
- Character limits do not affect the `Ellipsis`, as otherwise this would only add extra dots.
- For strings, limits first cause the string to be truncated, and only then is the string sent to the `repr()` function, where quotes and escape characters are added to it. The length of the ellipsis and quotes is not taken into account when truncating the string.
- The rules for applying limits are now the same for regular and byte strings.
- The display of objects has changed slightly in cases where an exception was raised during representation.
- Limited support for ternary expressions was added to the `@repred` decorator.