### PR TITLE
0.0.25

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ print(
 #> MyClass(a=1, ...)
 ```
 
-If `total_limit` is too small to fit even `ClassName(...)`, a `ValueError` is raised. The minimum valid value is `len(class_name) + 5`.
+If `total_limit` is too small to fit even `ClassName()`, a `ValueError` is raised. The minimum valid value is `len(class_name) + 2`.
 
 
 ## Auto mode

--- a/printo/reprs.py
+++ b/printo/reprs.py
@@ -1,8 +1,18 @@
 import functools
+import sys
 from inspect import isclass, isfunction, ismethod
 from typing import Any
 
 from getsources import UncertaintyWithLambdasError, getclearsource
+
+
+@functools.lru_cache(maxsize=None)
+def _get_lambda_symbol() -> str:
+    try:
+        'λ'.encode(sys.stdout.encoding or 'utf-8')
+        return 'λ'
+    except UnicodeEncodeError:
+        return '<lambda>'
 
 
 def superrepr(value: Any) -> str:  # noqa: PLR0911
@@ -13,7 +23,7 @@ def superrepr(value: Any) -> str:  # noqa: PLR0911
             try:
                 return getclearsource(value)
             except (UncertaintyWithLambdasError, OSError):
-                return 'λ'
+                return _get_lambda_symbol()
 
         return result
 

--- a/printo/reprs.py
+++ b/printo/reprs.py
@@ -30,7 +30,7 @@ def superrepr(value: Any) -> str:  # noqa: PLR0911
 
             return result
 
-    if isinstance(value, functools.partial):
+    elif isinstance(value, functools.partial):
         from printo.describe import describe_data_object  # noqa: PLC0415
 
         return describe_data_object('functools.partial', (value.func, *value.args), value.keywords)

--- a/printo/reprs.py
+++ b/printo/reprs.py
@@ -16,10 +16,10 @@ def _get_lambda_symbol() -> str:
 
 
 def superrepr(value: Any) -> str:  # noqa: PLR0911
-    if isfunction(value):
+    if isfunction(value) or ismethod(value) or isclass(value):
         result = value.__name__
 
-        if result == '<lambda>':
+        if isfunction(value) and result == '<lambda>':
             try:
                 return getclearsource(value)
             except (UncertaintyWithLambdasError, OSError):
@@ -27,18 +27,10 @@ def superrepr(value: Any) -> str:  # noqa: PLR0911
 
         return result
 
-    if ismethod(value):
-        return value.__name__
-
-    if isclass(value):
-        return value.__name__
-
     if isinstance(value, functools.partial):
-        func_repr = superrepr(value.func)
-        parts = [func_repr]
-        parts.extend(superrepr(arg) for arg in value.args)
-        parts.extend(f'{k}={superrepr(v)}' for k, v in value.keywords.items())
-        return f'functools.partial({", ".join(parts)})'
+        from printo.describe import describe_data_object  # noqa: PLC0415
+
+        return describe_data_object('functools.partial', (value.func, *value.args), value.keywords)
 
     try:
         return repr(value)

--- a/printo/reprs.py
+++ b/printo/reprs.py
@@ -17,15 +17,18 @@ def _get_lambda_symbol() -> str:
 
 def superrepr(value: Any) -> str:  # noqa: PLR0911
     if isfunction(value) or ismethod(value) or isclass(value):
-        result = value.__name__
+        try:
+            result = value.__name__
+        except Exception:  # noqa: BLE001
+            pass
+        else:
+            if isfunction(value) and result == '<lambda>':
+                try:
+                    return getclearsource(value)
+                except (UncertaintyWithLambdasError, OSError):
+                    return _get_lambda_symbol()
 
-        if isfunction(value) and result == '<lambda>':
-            try:
-                return getclearsource(value)
-            except (UncertaintyWithLambdasError, OSError):
-                return _get_lambda_symbol()
-
-        return result
+            return result
 
     if isinstance(value, functools.partial):
         from printo.describe import describe_data_object  # noqa: PLC0415

--- a/printo/reprs.py
+++ b/printo/reprs.py
@@ -7,7 +7,7 @@ from getsources import UncertaintyWithLambdasError, getclearsource
 
 
 @functools.lru_cache(maxsize=None)
-def _get_lambda_symbol() -> str:
+def get_lambda_symbol() -> str:
     try:
         'λ'.encode(sys.stdout.encoding or 'utf-8')
         return 'λ'
@@ -26,7 +26,7 @@ def superrepr(value: Any) -> str:  # noqa: PLR0911
                 try:
                     return getclearsource(value)
                 except (UncertaintyWithLambdasError, OSError):
-                    return _get_lambda_symbol()
+                    return get_lambda_symbol()
 
             return result
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ paths_to_mutate="printo"
 runner="pytest"
 
 [tool.ruff]
-line-length = 1000
+line-length = 320
 lint.ignore = ['E501', 'E712', 'E731', 'PTH123', 'PTH118', 'PLR2004', 'PTH107', 'SIM105', 'SIM102', 'RET503', 'PLR0912', 'C901']
 lint.select = ["ERA001", "YTT", "ASYNC", "BLE", "B", "A", "COM", "INP", "PIE", "T20", "PT", "RSE", "RET", "SIM", "SLOT", "TID252", "ARG", "PTH", "I", "C90", "N", "E", "W", "D201", "D202", "D419", "F", "PL", "PLE", "PLR", "PLW", "RUF", "TRY201", "TRY400", "TRY401"]
 format.quote-style = "single"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ paths_to_mutate="printo"
 runner="pytest"
 
 [tool.ruff]
+line-length = 1000
 lint.ignore = ['E501', 'E712', 'E731', 'PTH123', 'PTH118', 'PLR2004', 'PTH107', 'SIM105', 'SIM102', 'RET503', 'PLR0912', 'C901']
 lint.select = ["ERA001", "YTT", "ASYNC", "BLE", "B", "A", "COM", "INP", "PIE", "T20", "PT", "RSE", "RET", "SIM", "SLOT", "TID252", "ARG", "PTH", "I", "C90", "N", "E", "W", "D201", "D202", "D419", "F", "PL", "PLE", "PLR", "PLW", "RUF", "TRY201", "TRY400", "TRY401"]
 format.quote-style = "single"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = 'setuptools.build_meta'
 
 [project]
 name = 'printo'
-version = '0.0.24'
+version = '0.0.25'
 authors = [
   { name='Evgeniy Blinov', email='zheni-b@yandex.ru' },
 ]

--- a/tests/units/test_describe.py
+++ b/tests/units/test_describe.py
@@ -278,26 +278,27 @@ def test_broken_repr_as_argument():
 
 
 def test_item_limit_basic():
-    # superrepr(12345) = '12345' (5 chars); item_limit=2 -> '12...'
+    """superrepr(12345) = '12345' (5 chars); item_limit=2 -> '12...'."""
     assert describe_data_object('C', (12345,), {}, item_limit=2) == 'C(12...)'
     assert describe_data_object('C', (), {'x': 12345}, item_limit=2) == 'C(x=12...)'
 
 
 def test_item_limit_not_exceeded():
-    # '12345' has 5 chars; item_limit=5 -> no truncation
+    """'12345' has 5 chars; item_limit=5 -> no truncation.
+    item_limit=4 -> '1234...'.
+    """
     assert describe_data_object('C', (12345,), {}, item_limit=5) == 'C(12345)'
-    # item_limit=4 -> '1234...'
     assert describe_data_object('C', (12345,), {}, item_limit=4) == 'C(1234...)'
 
 
 def test_item_limit_zero():
-    # item_limit=0 -> value fully replaced with '...'
+    """item_limit=0 -> value fully replaced with '...'."""
     assert describe_data_object('C', (12345,), {}, item_limit=0) == 'C(...)'
     assert describe_data_object('C', (), {'x': 12345}, item_limit=0) == 'C(x=...)'
 
 
 def test_item_limit_with_kwargs():
-    # limit applies only to the value part, not to 'key=value' as a whole
+    """limit applies only to the value part, not to 'key=value' as a whole."""
     assert describe_data_object('C', (), {'key': 12345}, item_limit=2) == 'C(key=12...)'
 
 
@@ -307,18 +308,19 @@ def test_item_limit_negative():
 
 
 def test_item_limit_with_placeholder():
-    # item_limit applies to placeholder strings too
+    """item_limit applies to placeholder strings too."""
     assert describe_data_object('C', (1,), {}, item_limit=2, placeholders={0: 'secret'}) == 'C(se...)'
 
 
 def test_item_limit_with_placeholder_not_exceeded():
-    # placeholder shorter than item_limit — no truncation
+    """placeholder shorter than item_limit — no truncation."""
     assert describe_data_object('C', (1,), {}, item_limit=10, placeholders={0: 'ok'}) == 'C(ok)'
 
 
 def test_total_limit_basic():
-    # 'C(a=1, b=2, c=3)' = 16 chars; total_limit=10
-    # content 'C(a=1, b=2)' = 11 > 10; content 'C(a=1)' = 7 <= 10 -> output 'C(a=1, ...)'
+    """'C(a=1, b=2, c=3)' = 16 chars; total_limit=10.
+    content 'C(a=1, b=2)' = 11 > 10; content 'C(a=1)' = 7 <= 10 -> output 'C(a=1, ...)'.
+    """
     assert describe_data_object('C', (), {'a': 1, 'b': 2, 'c': 3}, total_limit=10) == 'C(a=1, ...)'
 
 
@@ -329,18 +331,20 @@ def test_total_limit_not_exceeded():
 
 
 def test_total_limit_drops_to_ellipsis_only():
-    # First item doesn't fit — result is ClassName(...)
-    # 'Name(x=12345)' = 13 chars; total_limit=9 = minimum for 'Name' -> 'Name(...)'
+    """First item doesn't fit — result is ClassName(...).
+    'Name(x=12345)' = 13 chars; total_limit=9 = minimum for 'Name' -> 'Name(...)'.
+    """
     assert describe_data_object('Name', (), {'x': 12345}, total_limit=9) == 'Name(...)'
 
 
 def test_total_limit_minimum():
-    # Minimum is len(class_name) + 2; the actual output 'A(...)' may be longer
+    """Minimum is len(class_name) + 2; the actual output 'A(...)' may be longer."""
     name = 'A'
     minimum = len(name) + 2  # = 3
     result = describe_data_object(name, (1, 2, 3), {}, total_limit=minimum)
+    
     assert result == 'A(...)'
-    # Output is longer than total_limit because '...' marker doesn't count
+    # Output is longer than total_limit because '...' marker doesn't count.
     assert len(result) > minimum
 
 
@@ -355,168 +359,178 @@ def test_total_limit_negative():
 
 
 def test_total_limit_with_item_limit():
-    # item_limit=2 truncates '12345' -> '12...', '1' stays as '1'
-    # chunks: ['a=1', 'b=12...'] -> full: 'C(a=1, b=12...)' = 15 chars
-    # total_limit=11: k=1 -> 'C(a=1, ...)' = 11 chars <= 11 ✓
+    """item_limit=2 truncates '12345' -> '12...', '1' stays as '1'.
+    chunks: ['a=1', 'b=12...'] -> full: 'C(a=1, b=12...)' = 15 chars.
+    total_limit=11: k=1 -> 'C(a=1, ...)' = 11 chars <= 11 ✓.
+    """
     assert describe_data_object('C', (), {'a': 1, 'b': 12345}, item_limit=2, total_limit=11) == 'C(a=1, ...)'
 
 
 def test_total_limit_first_item_too_long():
-    # First and only item exceeds total_limit -> 'C(...)'
-    # 'C(a=12345)' = 10 chars; total_limit=6 = minimum -> 'C(...)'
+    """First and only item exceeds total_limit -> 'C(...)'.
+    'C(a=12345)' = 10 chars; total_limit=6 = minimum -> 'C(...)'.
+    """
     assert describe_data_object('C', (), {'a': 12345}, total_limit=6) == 'C(...)'
 
 
 def test_total_limit_exact_fit():
-    # 'A(1, 2, 3)' = 10 chars; total_limit=10 -> no truncation
+    """'A(1, 2, 3)' = 10 chars; total_limit=10 -> no truncation."""
     result = describe_data_object('A', (1, 2, 3), {})
     assert result == 'A(1, 2, 3)'
     assert describe_data_object('A', (1, 2, 3), {}, total_limit=len(result)) == result
 
 
 def test_item_limit_string_basic():
-    # len('hello world') = 11 > 5; truncate to 5 raw chars -> repr('hello') + '...'
+    """len('hello world') = 11 > 5; truncate to 5 raw chars -> repr('hello') + '...'."""
     assert describe_data_object('C', ('hello world',), {}, item_limit=5) == "C('hello'...)"
     assert describe_data_object('C', (), {'name': 'hello world'}, item_limit=5) == "C(name='hello'...)"
 
 
 def test_item_limit_string_exact_boundary():
-    # len('abc') = 3 == item_limit=3 -> no truncation
+    """len('abc') = 3 == item_limit=3 -> no truncation."""
     assert describe_data_object('C', ('abc',), {}, item_limit=3) == "C('abc')"
 
 
 def test_item_limit_string_one_over():
-    # len('abcd') = 4 > item_limit=3 -> repr('abc') + '...'
+    """len('abcd') = 4 > item_limit=3 -> repr('abc') + '...'."""
     assert describe_data_object('C', ('abcd',), {}, item_limit=3) == "C('abc'...)"
 
 
 def test_item_limit_string_zero():
-    # item_limit=0: any non-empty string -> repr('') + '...' = "''" + '...'
+    """item_limit=0: any non-empty string -> repr('') + '...' = "''" + '...'."""
     assert describe_data_object('C', ('abc',), {}, item_limit=0) == "C(''...)"
 
 
 def test_item_limit_string_not_exceeded():
-    # len('hi') = 2; item_limit=2 -> no truncation; item_limit=3 -> also no truncation
+    """len('hi') = 2; item_limit=2 -> no truncation; item_limit=3 -> also no truncation."""
     assert describe_data_object('C', ('hi',), {}, item_limit=2) == "C('hi')"
     assert describe_data_object('C', ('hi',), {}, item_limit=3) == "C('hi')"
 
 
 def test_item_limit_string_with_escape_chars():
-    # 'a\nb' has len=3 ('\n' is 1 raw char); item_limit=2 -> repr('a\n') + '...'
+    """'a\\nb' has len=3 ('\\n' is 1 raw char); item_limit=2 -> repr('a\\n') + '...'."""
     assert describe_data_object('C', ('a\nb',), {}, item_limit=2) == "C('a\\n'...)"
 
 
 def test_item_limit_string_kwargs():
-    # Truncation by raw length applies to kwargs values too
+    """Truncation by raw length applies to kwargs values too."""
     assert describe_data_object('C', (), {'name': 'abcdef'}, item_limit=2) == "C(name='ab'...)"
 
 
 def test_item_limit_string_custom_serializer():
-    # Custom serializer: result doesn't equal repr(value), so generic truncation applies
+    """Custom serializer: result doesn't equal repr(value), so generic truncation applies."""
     assert describe_data_object('C', ('hello',), {}, serializer=lambda x: str(x), item_limit=3) == 'C(hel...)'
 
 
 def test_item_limit_bytes_basic():
-    # len(b'hello world') = 11 > 5; truncate to 5 raw bytes -> repr(b'hello') + '...'
+    """len(b'hello world') = 11 > 5; truncate to 5 raw bytes -> repr(b'hello') + '...'."""
     assert describe_data_object('C', (b'hello world',), {}, item_limit=5) == "C(b'hello'...)"
 
 
 def test_item_limit_bytes_exact_boundary():
-    # len(b'abc') = 3 == item_limit=3 -> no truncation
+    """len(b'abc') = 3 == item_limit=3 -> no truncation."""
     assert describe_data_object('C', (b'abc',), {}, item_limit=3) == "C(b'abc')"
 
 
 def test_item_limit_bytes_one_over():
-    # len(b'abcd') = 4 > item_limit=3 -> repr(b'abc') + '...'
+    """len(b'abcd') = 4 > item_limit=3 -> repr(b'abc') + '...'."""
     assert describe_data_object('C', (b'abcd',), {}, item_limit=3) == "C(b'abc'...)"
 
 
 def test_item_limit_bytes_zero():
-    # item_limit=0: any non-empty bytes -> repr(b'') + '...'
+    """item_limit=0: any non-empty bytes -> repr(b'') + '...'."""
     assert describe_data_object('C', (b'abc',), {}, item_limit=0) == "C(b''...)"
 
 
 def test_item_limit_bytes_with_non_ascii():
-    # Non-ASCII bytes: repr uses escape sequences, but limit counts raw bytes
-    # len(b'\xff\xfe') = 2; item_limit=1 -> repr(b'\xff') + '...'
+    """Non-ASCII bytes: repr uses escape sequences, but limit counts raw bytes.
+    len(b'\\xff\\xfe') = 2; item_limit=1 -> repr(b'\\xff') + '...'.
+    """
     assert describe_data_object('C', (b'\xff\xfe',), {}, item_limit=1) == "C(b'\\xff'...)"
 
 
 def test_item_and_chunk_truncation_coexist():
-    # item_limit truncates '123456' -> '12...'; total_limit then drops 'b=2' chunk
-    # chunks after item_limit: ['a=12...', 'b=2']; full = 'S(a=12..., b=2)' = 15
-    # total_limit=10: content 'S(a=12...)' = 10 <= 10 -> output 'S(a=12..., ...)'
+    """item_limit truncates '123456' -> '12...'; total_limit then drops 'b=2' chunk.
+    chunks after item_limit: ['a=12...', 'b=2']; full = 'S(a=12..., b=2)' = 15.
+    total_limit=10: content 'S(a=12...)' = 10 <= 10 -> output 'S(a=12..., ...)'.
+    """
     result = describe_data_object('S', (), {'a': 123456, 'b': 2}, item_limit=2, total_limit=10)
     assert result == 'S(a=12..., ...)'
 
 
 def test_chunk_truncation_preserves_comma():
-    # When k>0, output includes ', ...' (comma before ellipsis)
+    """When k>0, output includes ', ...' (comma before ellipsis)."""
     result = describe_data_object('C', (), {'a': 1, 'b': 2}, total_limit=7)
     assert result == 'C(a=1, ...)'
     assert ', ...' in result
 
 
 def test_chunk_truncation_no_comma_when_all_dropped():
-    # When all chunks dropped (k==0), output is 'ClassName(...)' without comma
+    """When all chunks dropped (k==0), output is 'ClassName(...)' without comma."""
     result = describe_data_object('C', (), {'a': 12345}, total_limit=3)
     assert result == 'C(...)'
     assert ', ...' not in result
 
 
 def test_item_limit_ellipsis_not_truncated():
-    # Ellipsis value is never truncated by item_limit
+    """Ellipsis value is never truncated by item_limit."""
     assert describe_data_object('C', (...,), {}, item_limit=1) == 'C(Ellipsis)'
     assert describe_data_object('C', (...,), {}, item_limit=0) == 'C(Ellipsis)'
 
 
 def test_item_limit_ellipsis_with_placeholder():
-    # Placeholder for Ellipsis is still subject to item_limit
+    """Placeholder for Ellipsis is still subject to item_limit."""
     assert describe_data_object('C', (...,), {}, item_limit=2, placeholders={0: 'secret'}) == 'C(se...)'
 
 
 def test_total_limit_output_longer_than_limit():
-    # '...' marker doesn't count toward total_limit, so output can exceed total_limit
-    # 'C(a=1)' = 7 chars <= total_limit=7; output = 'C(a=1, ...)' = 11 > 7
+    """'...' marker doesn't count toward total_limit, so output can exceed total_limit.
+    'C(a=1)' = 7 chars <= total_limit=7; output = 'C(a=1, ...)' = 11 > 7.
+    """
     result = describe_data_object('C', (), {'a': 1, 'b': 2}, total_limit=7)
     assert result == 'C(a=1, ...)'
     assert len(result) > 7
 
 
 def test_total_limit_ellipsis_not_dropped():
-    # Ellipsis argument is never dropped by total_limit
-    # 'C(Ellipsis, x=1)' = 17 chars; small total_limit should drop 'x=1' but keep Ellipsis
+    """Ellipsis argument is never dropped by total_limit.
+    'C(Ellipsis, x=1)' = 17 chars; small total_limit should drop 'x=1' but keep Ellipsis.
+    """
     result = describe_data_object('C', (...,), {'x': 1}, total_limit=13)
     assert result == 'C(Ellipsis, ...)'
 
 
 def test_total_limit_ellipsis_other_items_dropped():
-    # Non-Ellipsis items are dropped before Ellipsis
-    # 'C(Ellipsis, 1, 2)' = 18 chars
-    # Drop '2': content = 'C(Ellipsis, 1)' = 14 chars
-    # Drop '1': content = 'C(Ellipsis)' = 11 chars
+    """Non-Ellipsis items are dropped before Ellipsis.
+    'C(Ellipsis, 1, 2)' = 18 chars.
+    Drop '2': content = 'C(Ellipsis, 1)' = 14 chars.
+    Drop '1': content = 'C(Ellipsis)' = 11 chars.
+    """
     result = describe_data_object('C', (..., 1, 2), {}, total_limit=11)
     assert result == 'C(Ellipsis, ...)'
 
 
 def test_total_limit_all_ellipsis():
-    # All arguments are Ellipsis — nothing can be dropped
-    # Even if content exceeds total_limit, return full output (Ellipsis exemption)
+    """All arguments are Ellipsis — nothing can be dropped.
+    Even if content exceeds total_limit, return full output (Ellipsis exemption).
+    """
     result = describe_data_object('C', (..., ...), {}, total_limit=3)
     assert result == 'C(Ellipsis, Ellipsis)'
 
 
 def test_total_limit_ellipsis_pinned_content_exceeds_limit():
-    # Ellipsis + droppable item; even pinned-only content exceeds total_limit
-    # 'C(Ellipsis, 1)' = 14 > 3; drop '1': content 'C(Ellipsis)' = 11 > 3 -> fallback
-    # Returns pinned-only + '...' regardless of limit
+    """Ellipsis + droppable item; even pinned-only content exceeds total_limit.
+    'C(Ellipsis, 1)' = 14 > 3; drop '1': content 'C(Ellipsis)' = 11 > 3 -> fallback.
+    Returns pinned-only + '...' regardless of limit.
+    """
     result = describe_data_object('C', (..., 1), {}, total_limit=3)
     assert result == 'C(Ellipsis, ...)'
 
 
 def test_total_limit_ellipsis_mixed_positions():
-    # Ellipsis in the middle — order preserved, non-Ellipsis dropped from the end
-    # 'C(1, Ellipsis, 2)' = 18 chars
-    # Drop '2': content = 'C(1, Ellipsis)' = 14 chars
+    """Ellipsis in the middle — order preserved, non-Ellipsis dropped from the end.
+    'C(1, Ellipsis, 2)' = 18 chars.
+    Drop '2': content = 'C(1, Ellipsis)' = 14 chars.
+    """
     result = describe_data_object('C', (1, ..., 2), {}, total_limit=14)
     assert result == 'C(1, Ellipsis, ...)'

--- a/tests/units/test_describe.py
+++ b/tests/units/test_describe.py
@@ -285,6 +285,7 @@ def test_item_limit_basic():
 
 def test_item_limit_not_exceeded():
     """'12345' has 5 chars; item_limit=5 -> no truncation.
+
     item_limit=4 -> '1234...'.
     """
     assert describe_data_object('C', (12345,), {}, item_limit=5) == 'C(12345)'
@@ -319,6 +320,7 @@ def test_item_limit_with_placeholder_not_exceeded():
 
 def test_total_limit_basic():
     """'C(a=1, b=2, c=3)' = 16 chars; total_limit=10.
+
     content 'C(a=1, b=2)' = 11 > 10; content 'C(a=1)' = 7 <= 10 -> output 'C(a=1, ...)'.
     """
     assert describe_data_object('C', (), {'a': 1, 'b': 2, 'c': 3}, total_limit=10) == 'C(a=1, ...)'
@@ -332,6 +334,7 @@ def test_total_limit_not_exceeded():
 
 def test_total_limit_drops_to_ellipsis_only():
     """First item doesn't fit — result is ClassName(...).
+
     'Name(x=12345)' = 13 chars; total_limit=9 = minimum for 'Name' -> 'Name(...)'.
     """
     assert describe_data_object('Name', (), {'x': 12345}, total_limit=9) == 'Name(...)'
@@ -360,6 +363,7 @@ def test_total_limit_negative():
 
 def test_total_limit_with_item_limit():
     """item_limit=2 truncates '12345' -> '12...', '1' stays as '1'.
+
     chunks: ['a=1', 'b=12...'] -> full: 'C(a=1, b=12...)' = 15 chars.
     total_limit=11: k=1 -> 'C(a=1, ...)' = 11 chars <= 11 ✓.
     """
@@ -368,6 +372,7 @@ def test_total_limit_with_item_limit():
 
 def test_total_limit_first_item_too_long():
     """First and only item exceeds total_limit -> 'C(...)'.
+
     'C(a=12345)' = 10 chars; total_limit=6 = minimum -> 'C(...)'.
     """
     assert describe_data_object('C', (), {'a': 12345}, total_limit=6) == 'C(...)'
@@ -444,6 +449,7 @@ def test_item_limit_bytes_zero():
 
 def test_item_limit_bytes_with_non_ascii():
     """Non-ASCII bytes: repr uses escape sequences, but limit counts raw bytes.
+
     len(b'\\xff\\xfe') = 2; item_limit=1 -> repr(b'\\xff') + '...'.
     """
     assert describe_data_object('C', (b'\xff\xfe',), {}, item_limit=1) == "C(b'\\xff'...)"
@@ -451,6 +457,7 @@ def test_item_limit_bytes_with_non_ascii():
 
 def test_item_and_chunk_truncation_coexist():
     """item_limit truncates '123456' -> '12...'; total_limit then drops 'b=2' chunk.
+
     chunks after item_limit: ['a=12...', 'b=2']; full = 'S(a=12..., b=2)' = 15.
     total_limit=10: content 'S(a=12...)' = 10 <= 10 -> output 'S(a=12..., ...)'.
     """
@@ -485,6 +492,7 @@ def test_item_limit_ellipsis_with_placeholder():
 
 def test_total_limit_output_longer_than_limit():
     """'...' marker doesn't count toward total_limit, so output can exceed total_limit.
+
     'C(a=1)' = 7 chars <= total_limit=7; output = 'C(a=1, ...)' = 11 > 7.
     """
     result = describe_data_object('C', (), {'a': 1, 'b': 2}, total_limit=7)
@@ -494,6 +502,7 @@ def test_total_limit_output_longer_than_limit():
 
 def test_total_limit_ellipsis_not_dropped():
     """Ellipsis argument is never dropped by total_limit.
+
     'C(Ellipsis, x=1)' = 17 chars; small total_limit should drop 'x=1' but keep Ellipsis.
     """
     result = describe_data_object('C', (...,), {'x': 1}, total_limit=13)
@@ -502,6 +511,7 @@ def test_total_limit_ellipsis_not_dropped():
 
 def test_total_limit_ellipsis_other_items_dropped():
     """Non-Ellipsis items are dropped before Ellipsis.
+
     'C(Ellipsis, 1, 2)' = 18 chars.
     Drop '2': content = 'C(Ellipsis, 1)' = 14 chars.
     Drop '1': content = 'C(Ellipsis)' = 11 chars.
@@ -512,6 +522,7 @@ def test_total_limit_ellipsis_other_items_dropped():
 
 def test_total_limit_all_ellipsis():
     """All arguments are Ellipsis — nothing can be dropped.
+
     Even if content exceeds total_limit, return full output (Ellipsis exemption).
     """
     result = describe_data_object('C', (..., ...), {}, total_limit=3)
@@ -520,6 +531,7 @@ def test_total_limit_all_ellipsis():
 
 def test_total_limit_ellipsis_pinned_content_exceeds_limit():
     """Ellipsis + droppable item; even pinned-only content exceeds total_limit.
+
     'C(Ellipsis, 1)' = 14 > 3; drop '1': content 'C(Ellipsis)' = 11 > 3 -> fallback.
     Returns pinned-only + '...' regardless of limit.
     """
@@ -529,6 +541,7 @@ def test_total_limit_ellipsis_pinned_content_exceeds_limit():
 
 def test_total_limit_ellipsis_mixed_positions():
     """Ellipsis in the middle — order preserved, non-Ellipsis dropped from the end.
+
     'C(1, Ellipsis, 2)' = 18 chars.
     Drop '2': content = 'C(1, Ellipsis)' = 14 chars.
     """

--- a/tests/units/test_describe.py
+++ b/tests/units/test_describe.py
@@ -284,7 +284,8 @@ def test_item_limit_basic():
 
 
 def test_item_limit_not_exceeded():
-    """'12345' has 5 chars; item_limit=5 -> no truncation.
+    """
+    '12345' has 5 chars; item_limit=5 -> no truncation.
 
     item_limit=4 -> '1234...'.
     """
@@ -319,7 +320,8 @@ def test_item_limit_with_placeholder_not_exceeded():
 
 
 def test_total_limit_basic():
-    """'C(a=1, b=2, c=3)' = 16 chars; total_limit=10.
+    """
+    'C(a=1, b=2, c=3)' = 16 chars; total_limit=10.
 
     content 'C(a=1, b=2)' = 11 > 10; content 'C(a=1)' = 7 <= 10 -> output 'C(a=1, ...)'.
     """
@@ -333,7 +335,8 @@ def test_total_limit_not_exceeded():
 
 
 def test_total_limit_drops_to_ellipsis_only():
-    """First item doesn't fit — result is ClassName(...).
+    """
+    First item doesn't fit — result is ClassName(...).
 
     'Name(x=12345)' = 13 chars; total_limit=9 = minimum for 'Name' -> 'Name(...)'.
     """
@@ -345,7 +348,7 @@ def test_total_limit_minimum():
     name = 'A'
     minimum = len(name) + 2  # = 3
     result = describe_data_object(name, (1, 2, 3), {}, total_limit=minimum)
-    
+
     assert result == 'A(...)'
     # Output is longer than total_limit because '...' marker doesn't count.
     assert len(result) > minimum
@@ -362,7 +365,8 @@ def test_total_limit_negative():
 
 
 def test_total_limit_with_item_limit():
-    """item_limit=2 truncates '12345' -> '12...', '1' stays as '1'.
+    """
+    item_limit=2 truncates '12345' -> '12...', '1' stays as '1'.
 
     chunks: ['a=1', 'b=12...'] -> full: 'C(a=1, b=12...)' = 15 chars.
     total_limit=11: k=1 -> 'C(a=1, ...)' = 11 chars <= 11 ✓.
@@ -371,7 +375,8 @@ def test_total_limit_with_item_limit():
 
 
 def test_total_limit_first_item_too_long():
-    """First and only item exceeds total_limit -> 'C(...)'.
+    """
+    First and only item exceeds total_limit -> 'C(...)'.
 
     'C(a=12345)' = 10 chars; total_limit=6 = minimum -> 'C(...)'.
     """
@@ -448,7 +453,8 @@ def test_item_limit_bytes_zero():
 
 
 def test_item_limit_bytes_with_non_ascii():
-    """Non-ASCII bytes: repr uses escape sequences, but limit counts raw bytes.
+    """
+    Non-ASCII bytes: repr uses escape sequences, but limit counts raw bytes.
 
     len(b'\\xff\\xfe') = 2; item_limit=1 -> repr(b'\\xff') + '...'.
     """
@@ -456,7 +462,8 @@ def test_item_limit_bytes_with_non_ascii():
 
 
 def test_item_and_chunk_truncation_coexist():
-    """item_limit truncates '123456' -> '12...'; total_limit then drops 'b=2' chunk.
+    """
+    item_limit truncates '123456' -> '12...'; total_limit then drops 'b=2' chunk.
 
     chunks after item_limit: ['a=12...', 'b=2']; full = 'S(a=12..., b=2)' = 15.
     total_limit=10: content 'S(a=12...)' = 10 <= 10 -> output 'S(a=12..., ...)'.
@@ -491,7 +498,8 @@ def test_item_limit_ellipsis_with_placeholder():
 
 
 def test_total_limit_output_longer_than_limit():
-    """'...' marker doesn't count toward total_limit, so output can exceed total_limit.
+    """
+    '...' marker doesn't count toward total_limit, so output can exceed total_limit.
 
     'C(a=1)' = 7 chars <= total_limit=7; output = 'C(a=1, ...)' = 11 > 7.
     """
@@ -501,7 +509,8 @@ def test_total_limit_output_longer_than_limit():
 
 
 def test_total_limit_ellipsis_not_dropped():
-    """Ellipsis argument is never dropped by total_limit.
+    """
+    Ellipsis argument is never dropped by total_limit.
 
     'C(Ellipsis, x=1)' = 17 chars; small total_limit should drop 'x=1' but keep Ellipsis.
     """
@@ -510,7 +519,8 @@ def test_total_limit_ellipsis_not_dropped():
 
 
 def test_total_limit_ellipsis_other_items_dropped():
-    """Non-Ellipsis items are dropped before Ellipsis.
+    """
+    Non-Ellipsis items are dropped before Ellipsis.
 
     'C(Ellipsis, 1, 2)' = 18 chars.
     Drop '2': content = 'C(Ellipsis, 1)' = 14 chars.
@@ -521,7 +531,8 @@ def test_total_limit_ellipsis_other_items_dropped():
 
 
 def test_total_limit_all_ellipsis():
-    """All arguments are Ellipsis — nothing can be dropped.
+    """
+    All arguments are Ellipsis — nothing can be dropped.
 
     Even if content exceeds total_limit, return full output (Ellipsis exemption).
     """
@@ -530,7 +541,8 @@ def test_total_limit_all_ellipsis():
 
 
 def test_total_limit_ellipsis_pinned_content_exceeds_limit():
-    """Ellipsis + droppable item; even pinned-only content exceeds total_limit.
+    """
+    Ellipsis + droppable item; even pinned-only content exceeds total_limit.
 
     'C(Ellipsis, 1)' = 14 > 3; drop '1': content 'C(Ellipsis)' = 11 > 3 -> fallback.
     Returns pinned-only + '...' regardless of limit.
@@ -540,7 +552,8 @@ def test_total_limit_ellipsis_pinned_content_exceeds_limit():
 
 
 def test_total_limit_ellipsis_mixed_positions():
-    """Ellipsis in the middle — order preserved, non-Ellipsis dropped from the end.
+    """
+    Ellipsis in the middle — order preserved, non-Ellipsis dropped from the end.
 
     'C(1, Ellipsis, 2)' = 18 chars.
     Drop '2': content = 'C(1, Ellipsis)' = 14 chars.

--- a/tests/units/test_describe.py
+++ b/tests/units/test_describe.py
@@ -558,5 +558,4 @@ def test_total_limit_ellipsis_mixed_positions():
     'C(1, Ellipsis, 2)' = 18 chars.
     Drop '2': content = 'C(1, Ellipsis)' = 14 chars.
     """
-    result = describe_data_object('C', (1, ..., 2), {}, total_limit=14)
-    assert result == 'C(1, Ellipsis, ...)'
+    assert describe_data_object('C', (1, ..., 2), {}, total_limit=14) == 'C(1, Ellipsis, ...)'

--- a/tests/units/test_filters.py
+++ b/tests/units/test_filters.py
@@ -2,7 +2,6 @@ from printo import not_none
 
 
 def test_not_none():
-
     assert not_none(None) == False
 
     assert not_none(1) == True

--- a/tests/units/test_filters.py
+++ b/tests/units/test_filters.py
@@ -2,6 +2,7 @@ from printo import not_none
 
 
 def test_not_none():
+
     assert not_none(None) == False
 
     assert not_none(1) == True

--- a/tests/units/test_repred.py
+++ b/tests/units/test_repred.py
@@ -449,12 +449,12 @@ def test_simple_ignore():
 
 
 def test_conditional_expressions():
+    """@repred reads self.a at repr time, which stores the result of the expression."""
     @repred
     class SomeClass:
         def __init__(self, a):
             self.a = a if a else 123
 
-    # @repred reads self.a at repr time, which stores the result of the expression
     assert repr(SomeClass(42)) == 'SomeClass(a=42)'
     assert repr(SomeClass(0)) == 'SomeClass(a=123)'
 
@@ -470,17 +470,18 @@ def test_conditional_expression_reversed():
 
 
 def test_conditional_expression_with_default_value():
+    """When a=None (default), self.a stores 'default', which differs from default None -> shown."""
     @repred
     class SomeClass:
         def __init__(self, a=None):
             self.a = a if a is not None else 'default'
 
-    # When a=None (default), self.a stores 'default', which differs from default None -> shown
     assert repr(SomeClass()) == "SomeClass(a='default')"
     assert repr(SomeClass(42)) == 'SomeClass(a=42)'
 
 
 def test_conditional_expression_multiple_params():
+    """self.a = 0 if 0 else 0 = 0; self.c = 'fallback' if not 0 else 0 = 'fallback'."""
     @repred
     class SomeClass:
         def __init__(self, a, b, c):
@@ -489,7 +490,6 @@ def test_conditional_expression_multiple_params():
             self.c = 'fallback' if not c else c  # noqa: SIM212
 
     assert repr(SomeClass(1, 2, 3)) == 'SomeClass(a=1, b=2, c=3)'
-    # self.a = 0 if 0 else 0 = 0; self.c = 'fallback' if not 0 else 0 = 'fallback'
     assert repr(SomeClass(0, 2, 0)) == "SomeClass(a=0, b=2, c='fallback')"
 
 
@@ -502,7 +502,7 @@ def test_conditional_expression_not_recognized():
 
 
 def test_conditional_expression_nested():
-    # orelse is IfExp -> nested ternary, not supported; self.a not mapped -> error
+    """orelse is IfExp -> nested ternary, not supported; self.a not mapped -> error."""
     with pytest.raises(ParameterMappingNotFoundError, match=match('No internal object property or custom getter was found for the parameter a.')):
         @repred
         class SomeClass:
@@ -512,7 +512,7 @@ def test_conditional_expression_nested():
 
 
 def test_conditional_expression_both_branches_are_params():
-    # Both branches are different params -> AmbiguousMappingError
+    """Both branches are different params -> AmbiguousMappingError."""
     with pytest.raises(AmbiguousMappingError):
         @repred
         class SomeClass:
@@ -637,7 +637,7 @@ def test_ternary_ambiguity_one_getter_missing():
 
 
 def test_ternary_ambiguity_one_ignored():
-    # One param ignored, the other has no getter -> still AmbiguousMappingError
+    """One param ignored, the other has no getter -> still AmbiguousMappingError."""
     with pytest.raises(AmbiguousMappingError):
         @repred(ignore=['a'])
         class SomeClass:
@@ -665,7 +665,7 @@ def test_ternary_ambiguity_one_ignored_one_getter():
 
 
 def test_ternary_same_param_both_branches():
-    # self.a = a if cond else a — both branches same param, not ambiguous
+    """self.a = a if cond else a — both branches same param, not ambiguous."""
     @repred
     class SomeClass:
         def __init__(self, a):
@@ -676,7 +676,7 @@ def test_ternary_same_param_both_branches():
 
 
 def test_nested_ternary_rejected():
-    # body is IfExp -> nested, not supported -> self.a not mapped -> ParameterMappingNotFoundError
+    """body is IfExp -> nested, not supported -> self.a not mapped -> ParameterMappingNotFoundError."""
     with pytest.raises(ParameterMappingNotFoundError, match=match('No internal object property or custom getter was found for the parameter a.')):
         @repred
         class SomeClass:
@@ -687,7 +687,7 @@ def test_nested_ternary_rejected():
 
 
 def test_nested_ternary_in_orelse():
-    # orelse is IfExp -> nested, not supported -> self.a not mapped -> ParameterMappingNotFoundError
+    """orelse is IfExp -> nested, not supported -> self.a not mapped -> ParameterMappingNotFoundError."""
     with pytest.raises(ParameterMappingNotFoundError, match=match('No internal object property or custom getter was found for the parameter a.')):
         @repred
         class SomeClass:
@@ -698,7 +698,7 @@ def test_nested_ternary_in_orelse():
 
 
 def test_nested_ternary_with_getter():
-    # Nested ternary + getter for the unmapped param -> works fine
+    """Nested ternary + getter for the unmapped param -> works fine."""
     @repred(getters={'a': lambda obj: obj.a})
     class SomeClass:
         def __init__(self, a, b):
@@ -709,7 +709,7 @@ def test_nested_ternary_with_getter():
 
 
 def test_init_with_non_name_non_ifexp_assignment():
-    # self.x = 42 is a Constant (not Name, not IfExp) — get_mapping skips it
+    """self.x = 42 is a Constant (not Name, not IfExp) — get_mapping skips it."""
     @repred
     class SomeClass:
         def __init__(self, a):

--- a/tests/units/test_reprs.py
+++ b/tests/units/test_reprs.py
@@ -230,6 +230,5 @@ def test_superrepr_for_class_with_broken_name():
     class BadNameClass(metaclass=BadNameMeta):
         pass
 
-    expected = "<class 'tests.units.test_reprs.test_superrepr_for_class_with_broken_name.<locals>.BadNameClass'>"
-    assert superrepr(BadNameClass) == expected
+    assert superrepr(BadNameClass) == "<class 'tests.units.test_reprs.test_superrepr_for_class_with_broken_name.<locals>.BadNameClass'>"
     assert superrepr(BadNameClass) == repr(BadNameClass)

--- a/tests/units/test_reprs.py
+++ b/tests/units/test_reprs.py
@@ -9,6 +9,7 @@ from printo.reprs import _get_lambda_symbol, superrepr
 
 
 def test_superrepr_basically_is_repr():
+
     assert superrepr(1) == "1"
     assert superrepr("hello") == "'hello'"
     assert superrepr([1, 2, 3]) == "[1, 2, 3]"
@@ -56,9 +57,10 @@ def test_lambda_symbol_non_unicode_terminal():
 
 
 def test_superrepr_for_lambda_on_non_unicode_terminal():
-    # When stdout encoding can't represent λ, superrepr must return '<lambda>'.
-    # Two lambdas on one line guarantee UncertaintyWithLambdasError on any Python version,
-    # so the encoding fallback is always reached.
+    """When stdout encoding can't represent λ, superrepr must return '<lambda>'.
+    Two lambdas on one line guarantee UncertaintyWithLambdasError on any Python version,
+    so the encoding fallback is always reached.
+    """
     result = run(
         sys.executable, '-c',
         'from printo import superrepr; f = [lambda x: x, lambda y: y][0]; print(superrepr(f))',
@@ -72,8 +74,9 @@ def test_superrepr_for_lambda_on_non_unicode_terminal():
 
 @pytest.mark.skipif(sys.version_info >= (3, 13), reason='Python 3.13+ can introspect -c lambdas')
 def test_superrepr_for_lambda_without_source_old_python():
-    # On Python < 3.13, source of a lambda defined in -c is not retrievable.
-    # getclearsource raises OSError, and superrepr must fall back to 'λ'.
+    """On Python < 3.13, source of a lambda defined in -c is not retrievable.
+    getclearsource raises OSError, and superrepr must fall back to 'λ'.
+    """
     result = run(
         sys.executable, '-c',
         'from printo import superrepr; print(superrepr(lambda value, extra: False))',
@@ -87,8 +90,9 @@ def test_superrepr_for_lambda_without_source_old_python():
 
 @pytest.mark.skipif(sys.version_info < (3, 13), reason='Python < 3.13 cannot introspect -c lambdas')
 def test_superrepr_for_lambda_without_source_new_python():
-    # On Python 3.13+, source introspection for -c lambdas works,
-    # so superrepr returns the actual source code.
+    """On Python 3.13+, source introspection for -c lambdas works,
+    so superrepr returns the actual source code.
+    """
     result = run(
         sys.executable, '-c',
         'from printo import superrepr; print(superrepr(lambda value, extra: False))',

--- a/tests/units/test_reprs.py
+++ b/tests/units/test_reprs.py
@@ -211,3 +211,25 @@ def test_superrepr_for_object_with_broken_repr_and_broken_type():
             raise RuntimeError("repr is broken")
 
     assert superrepr(BrokenEverything()) == "<unprintable>"
+
+
+def test_superrepr_for_class_with_broken_name():
+    """
+    When __name__ raises, superrepr falls through to repr().
+
+    type.__repr__ reads the class name via the C-level tp_name slot, bypassing
+    Python-level __getattribute__, so repr() succeeds and returns the standard
+    class repr string like "<class '...BadNameClass'>".
+    """
+    class BadNameMeta(type):
+        def __getattribute__(cls, name: str) -> object:
+            if name == '__name__':
+                raise RuntimeError('broken __name__')
+            return super().__getattribute__(name)
+
+    class BadNameClass(metaclass=BadNameMeta):
+        pass
+
+    expected = "<class 'tests.units.test_reprs.test_superrepr_for_class_with_broken_name.<locals>.BadNameClass'>"
+    assert superrepr(BadNameClass) == expected
+    assert superrepr(BadNameClass) == repr(BadNameClass)

--- a/tests/units/test_reprs.py
+++ b/tests/units/test_reprs.py
@@ -5,7 +5,7 @@ import sys
 import pytest
 from suby import run
 
-from printo.reprs import _get_lambda_symbol, superrepr
+from printo.reprs import get_lambda_symbol, superrepr
 
 
 def test_superrepr_basically_is_repr():
@@ -42,18 +42,18 @@ def test_superrepr_for_lambda_functions_when_they_are_multple_in_one_line():
 
 
 def test_lambda_symbol_unicode_terminal():
-    assert _get_lambda_symbol() == 'λ'
+    assert get_lambda_symbol() == 'λ'
 
 
 def test_lambda_symbol_non_unicode_terminal():
     original_stdout = sys.stdout
     sys.stdout = io.TextIOWrapper(io.BytesIO(), encoding='ascii')
     try:
-        _get_lambda_symbol.cache_clear()
-        assert _get_lambda_symbol() == '<lambda>'
+        get_lambda_symbol.cache_clear()
+        assert get_lambda_symbol() == '<lambda>'
     finally:
         sys.stdout = original_stdout
-        _get_lambda_symbol.cache_clear()
+        get_lambda_symbol.cache_clear()
 
 
 def test_superrepr_for_lambda_on_non_unicode_terminal():

--- a/tests/units/test_reprs.py
+++ b/tests/units/test_reprs.py
@@ -57,15 +57,17 @@ def test_lambda_symbol_non_unicode_terminal():
 
 def test_superrepr_for_lambda_on_non_unicode_terminal():
     # When stdout encoding can't represent λ, superrepr must return '<lambda>'.
+    # Two lambdas on one line guarantee UncertaintyWithLambdasError on any Python version,
+    # so the encoding fallback is always reached.
     result = run(
         sys.executable, '-c',
-        'from printo import superrepr; print(superrepr(lambda x: x))',
+        'from printo import superrepr; f = [lambda x: x, lambda y: y][0]; print(superrepr(f))',
         catch_output=True,
         split=False,
         add_env={'PYTHONIOENCODING': 'ascii', 'PYTHONUTF8': '0'},
     )
 
-    assert result.stdout.strip() == '<lambda>'
+    assert result.stdout.strip() == '<lambda>', f'stdout={result.stdout!r} stderr={result.stderr!r}'
 
 
 @pytest.mark.skipif(sys.version_info >= (3, 13), reason='Python 3.13+ can introspect -c lambdas')

--- a/tests/units/test_reprs.py
+++ b/tests/units/test_reprs.py
@@ -1,10 +1,11 @@
 import functools
+import io
 import sys
 
 import pytest
 from suby import run
 
-from printo.reprs import superrepr
+from printo.reprs import _get_lambda_symbol, superrepr
 
 
 def test_superrepr_basically_is_repr():
@@ -37,6 +38,34 @@ def test_superrepr_for_lambda_functions_when_they_are_multple_in_one_line():
 
     assert superrepr(lambdas[0]) == "λ"
     assert superrepr(lambdas[1]) == "λ"
+
+
+def test_lambda_symbol_unicode_terminal():
+    assert _get_lambda_symbol() == 'λ'
+
+
+def test_lambda_symbol_non_unicode_terminal():
+    original_stdout = sys.stdout
+    sys.stdout = io.TextIOWrapper(io.BytesIO(), encoding='ascii')
+    try:
+        _get_lambda_symbol.cache_clear()
+        assert _get_lambda_symbol() == '<lambda>'
+    finally:
+        sys.stdout = original_stdout
+        _get_lambda_symbol.cache_clear()
+
+
+def test_superrepr_for_lambda_on_non_unicode_terminal():
+    # When stdout encoding can't represent λ, superrepr must return '<lambda>'.
+    result = run(
+        sys.executable, '-c',
+        'from printo import superrepr; print(superrepr(lambda x: x))',
+        catch_output=True,
+        split=False,
+        add_env={'PYTHONIOENCODING': 'ascii', 'PYTHONUTF8': '0'},
+    )
+
+    assert result.stdout.strip() == '<lambda>'
 
 
 @pytest.mark.skipif(sys.version_info >= (3, 13), reason='Python 3.13+ can introspect -c lambdas')

--- a/tests/units/test_reprs.py
+++ b/tests/units/test_reprs.py
@@ -57,7 +57,8 @@ def test_lambda_symbol_non_unicode_terminal():
 
 
 def test_superrepr_for_lambda_on_non_unicode_terminal():
-    """When stdout encoding can't represent λ, superrepr must return '<lambda>'.
+    """
+    When stdout encoding can't represent λ, superrepr must return '<lambda>'.
 
     Two lambdas on one line guarantee UncertaintyWithLambdasError on any Python version,
     so the encoding fallback is always reached.
@@ -75,7 +76,8 @@ def test_superrepr_for_lambda_on_non_unicode_terminal():
 
 @pytest.mark.skipif(sys.version_info >= (3, 13), reason='Python 3.13+ can introspect -c lambdas')
 def test_superrepr_for_lambda_without_source_old_python():
-    """On Python < 3.13, source of a lambda defined in -c is not retrievable.
+    """
+    On Python < 3.13, source of a lambda defined in -c is not retrievable.
 
     getclearsource raises OSError, and superrepr must fall back to 'λ'.
     """

--- a/tests/units/test_reprs.py
+++ b/tests/units/test_reprs.py
@@ -58,6 +58,7 @@ def test_lambda_symbol_non_unicode_terminal():
 
 def test_superrepr_for_lambda_on_non_unicode_terminal():
     """When stdout encoding can't represent λ, superrepr must return '<lambda>'.
+
     Two lambdas on one line guarantee UncertaintyWithLambdasError on any Python version,
     so the encoding fallback is always reached.
     """
@@ -75,6 +76,7 @@ def test_superrepr_for_lambda_on_non_unicode_terminal():
 @pytest.mark.skipif(sys.version_info >= (3, 13), reason='Python 3.13+ can introspect -c lambdas')
 def test_superrepr_for_lambda_without_source_old_python():
     """On Python < 3.13, source of a lambda defined in -c is not retrievable.
+
     getclearsource raises OSError, and superrepr must fall back to 'λ'.
     """
     result = run(
@@ -90,9 +92,7 @@ def test_superrepr_for_lambda_without_source_old_python():
 
 @pytest.mark.skipif(sys.version_info < (3, 13), reason='Python < 3.13 cannot introspect -c lambdas')
 def test_superrepr_for_lambda_without_source_new_python():
-    """On Python 3.13+, source introspection for -c lambdas works,
-    so superrepr returns the actual source code.
-    """
+    """On Python 3.13+, source introspection for -c lambdas works, so superrepr returns the actual source code."""
     result = run(
         sys.executable, '-c',
         'from printo import superrepr; print(superrepr(lambda value, extra: False))',


### PR DESCRIPTION
Minor update:

- If the terminal does not support `Unicode`, the character `λ` (which denotes a lambda function) will now be displayed as the string `<lambda>`.
- Fixed another issue where an error that occurred while attempting to read an object's metadata could slip through.
- Refactored the core code and tests without affecting functionality.
- Fixed a minor error in the documentation.